### PR TITLE
URL regex validation does not allow "&" and "+" in get parameter

### DIFF
--- a/src/validator/validator.js
+++ b/src/validator/validator.js
@@ -20,7 +20,7 @@
 		
 		// http://net.tutsplus.com/tutorials/other/8-regular-expressions-you-should-know/
 		emailRe = /^([a-z0-9_\.\-\+]+)@([\da-z\.\-]+)\.([a-z\.]{2,6})$/i,
-		urlRe = /^(https?:\/\/)?[\da-z\.\-]+\.[a-z\.]{2,6}[#\?\/\w \.\-=]*$/i,
+		urlRe = /^(https?:\/\/)?[\da-z\.\-]+\.[a-z\.]{2,6}[#\?\/\w \.\-=&+]*$/i,
 		v;
 		 
 	v = $.tools.validator = {


### PR DESCRIPTION
"&" and "+" charactes are also valid URLs (e.g. http://www.youtube.com/watch?v=zZ_mFOG1H-o&feature=rec-LGOUT-exp_fresh+div-1r-9-HM)
