### PR TITLE
Children items on scrollable plugin

### DIFF
--- a/src/scrollable/scrollable.js
+++ b/src/scrollable/scrollable.js
@@ -92,7 +92,7 @@
 			},
 			
 			getItems: function() {
-				return itemWrap.children(conf.item).not("." + conf.clonedClass);	
+				return itemWrap.find(conf.item).not("." + conf.clonedClass);	
 			},
 							
 			move: function(offset, time) {


### PR DESCRIPTION
Hi there!

I changed the method "getItems" on the scrollable plugin to look for ".items" with "find()" jQuery method instead of "children()". I did this because there are situations where you need to scroll items that are not direct children of the scrollable element. I mean:

```
<div class="scrollable">
    <div class="wrapper">
        <div class="item">Scrollable!</div>
        <div class="item">Scrollable!</div>
        <div class="item">Scrollable!</div>
    </div>

    <div class="wrapper">
        <div class="item">Scrollable!</div>
        <div class="item">Scrollable!</div>
        <div class="item">Scrollable!</div>
    </div>

    <div class="item">Scrollable!</div>
    <div class="item">Scrollable!</div>
    <div class="item">Scrollable!</div>
</div>
```

In this case I need to scroll by the ".item" elements, but not all of them are direct children of ".scrollable", so with "find()" method instead of "children()" method  the plugin would find and use them to scroll.

On my initial tests it doesn't break anything else, but not sure if it will under some circunstances. I leave the pull request here just to warn about the issue.  
