### PR TITLE
Scrollable: addItemBefore(item)

### DIFF
--- a/src/scrollable/scrollable.js
+++ b/src/scrollable/scrollable.js
@@ -120,7 +120,7 @@
 				return self;
 			},
 			
-			addItem: function(item) {
+			appendItem: function(item) {
 				item = $(item);
 				
 				if (!conf.circular)  {
@@ -128,6 +128,20 @@
 				} else {
 					itemWrap.children("." + conf.clonedClass + ":last").before(item);
 					itemWrap.children("." + conf.clonedClass + ":first").replaceWith(item.clone().addClass(conf.clonedClass)); 						
+				}
+				
+				fire.trigger("onAddItem", [item]);
+				return self;
+			},
+			
+			prependItem: function(item) {
+				item = $(item);
+				
+				if (!conf.circular)  {
+					itemWrap.prepend(item);
+				} else {
+					itemWrap.children("." + conf.clonedClass + ":first").after(item);
+					itemWrap.children("." + conf.clonedClass + ":last").replaceWith(item.clone().addClass(conf.clonedClass)); 						
 				}
 				
 				fire.trigger("onAddItem", [item]);

--- a/src/scrollable/scrollable.js
+++ b/src/scrollable/scrollable.js
@@ -120,7 +120,7 @@
 				return self;
 			},
 			
-			appendItem: function(item) {
+			addItem: function(item) {
 				item = $(item);
 				
 				if (!conf.circular)  {
@@ -138,16 +138,17 @@
 				item = $(item);
 				
 				if (!conf.circular)  {
-					itemWrap.prepend(item);
+					itemWrap.prepend(item);					
 				} else {
 					itemWrap.children("." + conf.clonedClass + ":first").after(item);
 					itemWrap.children("." + conf.clonedClass + ":last").replaceWith(item.clone().addClass(conf.clonedClass)); 						
 				}
 				
-				fire.trigger("onAddItem", [item]);
+				self.seekTo(self.getIndex() +1, 0);
+				
+				fire.trigger("onPrependItem", [item]);
 				return self;
-			},
-			
+			},			
 			
 			/* all seeking functions depend on this */		
 			seekTo: function(i, time, fn) {	
@@ -193,7 +194,7 @@
 		});
 				
 		// callbacks	
-		$.each(['onBeforeSeek', 'onSeek', 'onAddItem'], function(i, name) {
+		$.each(['onBeforeSeek', 'onSeek', 'onAddItem', 'onPrependItem'], function(i, name) {
 				
 			// configuration
 			if ($.isFunction(conf[name])) { 

--- a/src/scrollable/scrollable.js
+++ b/src/scrollable/scrollable.js
@@ -134,7 +134,7 @@
 				return self;
 			},
 			
-			prependItem: function(item) {
+			addItemBefore: function(item) {
 				item = $(item);
 				
 				if (!conf.circular)  {
@@ -146,7 +146,7 @@
 				
 				self.seekTo(self.getIndex() +1, 0);
 				
-				fire.trigger("onPrependItem", [item]);
+				fire.trigger("onAddItemBefore", [item]);
 				return self;
 			},			
 			
@@ -194,7 +194,7 @@
 		});
 				
 		// callbacks	
-		$.each(['onBeforeSeek', 'onSeek', 'onAddItem', 'onPrependItem'], function(i, name) {
+		$.each(['onBeforeSeek', 'onSeek', 'onAddItem', 'onAddItemBefore'], function(i, name) {
 				
 			// configuration
 			if ($.isFunction(conf[name])) { 


### PR DESCRIPTION
I've added a new API method to Scrollable called addItemBefore, which prepends items to the front of a Scrollable. 

My use case for needing this was in building a scrolling calendar view, which loads in dates as items as you near the edges scrolling in either direction.

There is a forum thread with a number of people requesting this functionality:

http://flowplayer.org/tools/forum/35/40454
