### PR TITLE
A form with validator can't be submitted manually with $(form).submit()

### DIFF
--- a/src/validator/validator.js
+++ b/src/validator/validator.js
@@ -510,6 +510,9 @@
 				if (!self.checkValidity(null, e)) { 
 					return e.preventDefault(); 
 				}
+				// Reset event type and target
+				e.target = form;
+				e.type = conf.formEvent;
 			});
 		}
 		

--- a/test/validator/submit_manually.htm
+++ b/test/validator/submit_manually.htm
@@ -1,0 +1,21 @@
+<!DOCTYPE html>        
+<script src="../js/jquery-1.4.2.min.js"></script>
+<script src="../../src/validator/validator.js"></script>
+
+<form action="http://google.com/search" style="margin:100px">
+
+	<label>
+		requred text 
+		<input name="q" type="text" required="required" />
+	</label>
+
+  <a href="#" class="submit">Submit</a>
+</form>
+
+<script>
+$("form").validator({ position: 'top center'});
+$("a.submit").click(function(event) {
+  event.preventDefault();
+  $("form:first").submit();
+});
+</script>


### PR DESCRIPTION
Doing so triggers the validation, but if it passes the form is not submitted. I believe the reason is that the event attributes are changed several times in the checkValidation method. Reseting its type and target to original values seem to fix the problem (check the first commit with a test page to replicate the issue).
