### PR TITLE
Bug with min date & month / year in the picker

### DIFF
--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -499,7 +499,7 @@
 					// month selector
 					monthSelector.empty();
 					$.each(labels.months, function(i, m) {					
-						if (min < new Date(year, i + 1, -1) && max > new Date(year, i, 0)) {
+						if (min < new Date(year, i + 1, 1) && max > new Date(year, i, 0)) {
 							monthSelector.append($("<option/>").html(m).attr("value", i));
 						}
 					});
@@ -509,7 +509,7 @@
 					var yearNow = now.getFullYear();
 					
 					for (var i = yearNow + conf.yearRange[0];  i < yearNow + conf.yearRange[1]; i++) {
-						if (min <= new Date(i + 1, -1, 1) && max > new Date(i, 0, 0)) {
+						if (min < new Date(i + 1, 0, 1) && max > new Date(i, 0, 0)) {
 							yearSelector.append($("<option/>").text(i));
 						}
 					}		

--- a/test/dateinput/setmin.htm
+++ b/test/dateinput/setmin.htm
@@ -7,7 +7,7 @@
 <!-- HTML5 date input -->
 <input type="date" name="mydate" data-value="2010-12-01" min="2010-12-01" max="2011-12-02" />
 
-<input type="date" name="mydate" data-value="2010-12-01" min="2010-12-01" max="2012-07-01" />
+<input type="date" name="mydate" data-value="2010-12-30" min="2010-12-30" max="2012-07-01" />
 
 <!-- make it happen -->
 <script>


### PR DESCRIPTION
Please check the first commit where I've updated the test page to clearly show the issue. Basically when you set min date to the last or last but one day of a month and then open the picker, then the next month and/or year will be displayed in the selectors. This is due to incorrect check in the code (see the second commit for a fix). It'd be cool to get this merged asap as I don't think there's a way for users to add a fix in their own code.
