### PR TITLE
Bug when scrolling through months in the date picker

### DIFF
--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -335,10 +335,10 @@
 					
 					
 					if (index > 41) {
-						 self.addMonth();
+						 showNextMonth();
 						 el = $("#" + css.weeks + " a:eq(" + (index-42) + ")");
 					} else if (index < 0) {
-						 self.addMonth(-1);
+						 showPreviousMonth();
 						 el = $("#" + css.weeks + " a:eq(" + (index+42) + ")");
 					} else {
 						 el = days.eq(index);
@@ -350,8 +350,8 @@
 				}
 			 
 				// pageUp / pageDown
-				if (key == 34) { return self.addMonth(); }						
-				if (key == 33) { return self.addMonth(-1); }
+				if (key == 34) { return showNextMonth(); }						
+				if (key == 33) { return showPreviousMonth(); }
 				
 				// home
 				if (key == 36) { return self.today(); } 
@@ -379,6 +379,20 @@
 		}
 //}}}
 		
+
+//{{{ switch months in the picker
+	function showNextMonth() {
+		var daysNextMonth = dayAm(currYear, currMonth + 1);
+		// If next month has less days than the current date
+		// add number of days in the next month, otherwise add
+		// number of days in the current month
+		return self.addDay(currDay > daysNextMonth ? daysNextMonth : dayAm(currYear, currMonth));
+  }
+
+	function showPreviousMonth() {
+		return self.addDay(-dayAm(currYear, currMonth));
+	}
+//}}}
 		
 		$.extend(self, {
 
@@ -413,14 +427,14 @@
 				// prev / next month
 				pm = root.find("#" + css.prev).unbind("click").click(function(e) {
 					if (!pm.hasClass(css.disabled)) {	
-						self.addMonth(-1);
+						showPreviousMonth();
 					}
 					return false;
 				});
 				
 				nm = root.find("#" + css.next).unbind("click").click(function(e) {
 					if (!nm.hasClass(css.disabled)) {
-						self.addMonth();
+						showNextMonth();
 					}
 					return false;
 				});	 
@@ -459,7 +473,7 @@
 
 			setValue: function(year, month, day)  {
 				
-				var date = integer(month) >= -1 ? new Date(integer(year), integer(month), integer(day || 1)) : 
+				var date = integer(month) >= -1 ? new Date(integer(year), integer(month), integer(day == undefined || isNaN(day) ? 1 : day)) : 
 					year || value;				
 				
 				if (date < min) { date = min; }
@@ -486,6 +500,7 @@
 				
 				currMonth = month;
 				currYear = year;
+				currDay = day;
 
 				// variables
 				var tmp = new Date(year, month, 1 - conf.firstDay), begin = tmp.getDay(),

--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -90,7 +90,7 @@
 
 	// @return amount of days in certain month
 	function dayAm(year, month) {
-		return 32 - new Date(year, month, 32).getDate();		
+		return new Date(year, month + 1, 0).getDate();
 	}
  
 	function zeropad(val, len) {


### PR DESCRIPTION
This one is quite easy to replicate: just select 31 January in any datepicker and then try to switch to the next month either using the "next month" button in the picker or keyboard. You'll notice that you switch to March. Then try to switch to previous month and you'll see that you can't.

This is because the addMonth method is used to do that, which simply updates the month of the current value. In javascript when you update the month (for 31 Jan in our case) it also takes the date into account. Since there's no 31st in February it adds 3 or 4 days to the date and you get March:

```
> var date = new Date(2010, 0, 31)
> date
=> Sun Jan 31 2010 00:00:00 GMT+0300 (MSK)
> new Date(date.getFullYear(), date.getMonth() + 1, date.getDate())
=> Wed Mar 03 2010 00:00:00 GMT+0300 (MSK)
```

A similar thing happens when you switch to the previous month — the date is set to 31 Feb, it adds 3 or 4 days and you get March again, so you stay on the same month.

I'm not sure if this is an issue with the addMonth method. It's probably OK to have it working that way, but it'd be good to add a note about this to the documentation. But scrolling through months should definitely be fixed. That's why I've added 2 methods that are used exactly for this purpose (showNextMonth and showPreviousMonth). They add or substract the number of days in a given month. When adding it makes sure that the new date is going to be in the next month.

Another issue I've found while messing with this is that dayAm also works incorrectly:

```
> dayAm(1985, 2)
=> 31
> dayAm(1984, 2)
=> 1
```

It thinks that there was just 1 day in March 1984 (and precending years). It looks like it has something to do with switching to DST, which happened on March 31 in 1984 in Russia (my timezone):

```
> new Date(1984, 2, 32)
=> Sat Mar 31 1984 23:00:00 GMT+0300 (MSK)
> new Date(1985, 2, 32)
=> Mon Apr 01 1985 00:00:00 GMT+0400 (MSD)
```

In 1985 we switched to DST on 30 March, so it works correctly for that year. Anyway, I think a more robust implementation would be to check the date of the last day of the month like this: Date(year, month + 1, 0).getDate() which I committed as well.

Again, it'd be really helpful to get this fixed asap, as it's pretty critical I think.

Thanks!
