### PR TITLE
A fix for a crazy IE bug which was breaking circular

### DIFF
--- a/src/scrollable/scrollable.autoscroll.js
+++ b/src/scrollable/scrollable.autoscroll.js
@@ -18,7 +18,8 @@
 		conf: {
 			autoplay: true,
 			interval: 3000,
-			autopause: true
+			autopause: true,
+			direction: "forward"
 		}
 	};	
 	
@@ -48,7 +49,12 @@
 				
 				// construct new timer
 				timer = setInterval(function() { 
-					api.next();				
+				    if(opts.direction == "backward")
+				    {
+    					api.previous();				
+				    } else {
+    					api.next();				
+				    }
 				}, opts.interval);
 				
 			};	

--- a/src/scrollable/scrollable.js
+++ b/src/scrollable/scrollable.js
@@ -29,6 +29,7 @@
 			mousewheel: false,
 			next: '.next',   
 			prev: '.prev', 
+			size: 1,
 			speed: 400,
 			vertical: false,
 			touch: true,
@@ -195,8 +196,10 @@
 		// circular loop
 		if (conf.circular) {
 			
-			var cloned1 = self.getItems().slice(-1).clone().prependTo(itemWrap),
-				 cloned2 = self.getItems().eq(1).clone().appendTo(itemWrap);
+			var items = self.getItems();
+			var cloned1 = items.slice(-1).clone().prependTo(itemWrap),
+				 cloned2 = items.filter(":lt(" + conf.size + ")").clone().appendTo(itemWrap);
+				 items = null;
 				
 			cloned1.add(cloned2).addClass(conf.clonedClass);
 			

--- a/src/scrollable/scrollable.js
+++ b/src/scrollable/scrollable.js
@@ -148,7 +148,7 @@
 				// check that index is sane
 				// note that for some weird IE bug, you can't place the line below directly in an if statement otherwise circular will break		
 				var test = ((!conf.circular && i < 0) || i > self.getSize() || i < -1);
-				if (test) { console.log("Nope"); return self; }
+				if (test) { return self; }
 				
 				var item = i;
 			

--- a/src/scrollable/scrollable.js
+++ b/src/scrollable/scrollable.js
@@ -145,8 +145,10 @@
 				// avoid seeking from end clone to the beginning
 				if (conf.circular && i === 0 && index == -1 && time !== 0) { return self; }
 				
-				// check that index is sane				
-				if (!conf.circular && i < 0 || i > self.getSize() || i < -1) { return self; }
+				// check that index is sane
+				// note that for some weird IE bug, you can't place the line below directly in an if statement otherwise circular will break		
+				var test = ((!conf.circular && i < 0) || i > self.getSize() || i < -1);
+				if (test) { console.log("Nope"); return self; }
 				
 				var item = i;
 			


### PR DESCRIPTION
In addition to the previous pull request where I returned size to the scrollable config, I found a crazy IE bug where an if statement was evaluating to false for no reason unless pulled out into its own variable.
