### PR TITLE
fix tooltip with select tag

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -245,8 +245,10 @@
 					if (event[1] && !trigger.is("input:not(:checkbox, :radio), textarea")) { 					
 						tip.bind(event[1], function(e) {
 	
-							// being moved to the trigger element
-							if (e.relatedTarget != trigger[0]) {
+							// being moved to the trigger element or target is <select> tag.
+							// Chrom{e,ium} under Linux generates 'mouseout' event which in turn
+							// cause 'mouseover' for tooltip
+							if (e.relatedTarget != trigger[0] && !$(e.target).is('select')) {
 								trigger.trigger(evt[1].split(" ")[0]);
 							}
 						}); 


### PR DESCRIPTION
Hi guys

This patch fixes tooltip hiding in Chrom{e,ium} browsers under linux (it isn't reproduced under macos safari/chrome/firefox). To check this issue go to http://vivid-spring-57.heroku.com/ and try to move mouse over select tag in tooltip.

Thanks
