### PR TITLE
Fix keyboard issues

### DIFF
--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -699,8 +699,11 @@
 			// allow tab
 			return e.shiftKey || e.ctrlKey || e.altKey || key == 9 ? true : e.preventDefault();   
 			
-		}); 
-		
+		});
+
+	  // hide when focus is lost
+	  input.bind("blur", self.hide);
+  		
 		// initial value 		
 		if (parseDate(input.val())) { 
 			select(value, conf);

--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -275,6 +275,10 @@
 			currMonth = date.getMonth();
 			currDay	 = date.getDate();				
 			
+			// focus the input after selection (doesn't work in IE)
+			if (e.type == "click" && !$.browser.msie) {
+				input.focus();
+			}
 			
 			// change
 			e = e || $.Event("api");
@@ -638,9 +642,7 @@
 					if (e.isDefaultPrevented()) { return; }
 					
 					$(document).unbind("click.d").unbind("keydown.d");
-					input.focus();
-					input.select();
-					
+										
 					// do the hide
 					root.hide();
 					opened = false;

--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -307,7 +307,7 @@
 				var key = e.keyCode;			 
 				
 				// backspace or delete clears the value
-				if (key == 8 || key == 9) {
+				if (key == 8 || key == 46) {
 					input.val("");
 					return self.hide(e);	
 				}
@@ -692,10 +692,12 @@
 
 			var key = e.keyCode;
 	
-			// open dateinput with navigation keys, or clear value on backspace or delete
-			if (!opened &&  $(KEYS).index(key) >= 0) {
+			// open dateinput with navigation keys or spacebar
+			if (!opened && ($(KEYS).index(key) >= 0 || key == 32)) {
 				self.show(e);
 				return e.preventDefault();
+			
+			// clear value on backspace or delete
 			} else if (key == 8 || key == 46) {
 				input.val("");
 			}

--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -306,14 +306,14 @@
 				if (e.ctrlKey) { return true; }				
 				var key = e.keyCode;			 
 				
-				// backspace clears the value
-				if (key == 8) {
+				// backspace or delete clears the value
+				if (key == 8 || key == 9) {
 					input.val("");
 					return self.hide(e);	
 				}
 				
-				// esc key
-				if (key == 27) { return self.hide(e); }						
+				// esc or tab key exits
+				if (key == 27 || key == 9) { return self.hide(e); }						
 					
 				if ($(KEYS).index(key) >= 0) {
 					
@@ -634,10 +634,12 @@
 					e.type = "onHide";
 					fire.trigger(e);
 					
-					$(document).unbind("click.d").unbind("keydown.d");
-					
 					// cancelled ?
 					if (e.isDefaultPrevented()) { return; }
+					
+					$(document).unbind("click.d").unbind("keydown.d");
+					input.focus();
+					input.select();
 					
 					// do the hide
 					root.hide();
@@ -690,20 +692,19 @@
 
 			var key = e.keyCode;
 	
-			// open dateinput with navigation keyw
+			// open dateinput with navigation keys, or clear value on backspace or delete
 			if (!opened &&  $(KEYS).index(key) >= 0) {
 				self.show(e);
 				return e.preventDefault();
-			} 
+			} else if (key == 8 || key == 46) {
+				input.val("");
+			}
 			
 			// allow tab
 			return e.shiftKey || e.ctrlKey || e.altKey || key == 9 ? true : e.preventDefault();   
 			
-		});
-
-	  // hide when focus is lost
-	  input.bind("blur", self.hide);
-  		
+		}); 
+		
 		// initial value 		
 		if (parseDate(input.val())) { 
 			select(value, conf);


### PR DESCRIPTION
Fix tabbing through date input so calendar automatically hides
Fix backspace & delete button to always clear the value
Allow spacebar to reopen after a selection
When user clicks a date in calendar, refocus dateinput (except for in IE)
