### PR TITLE
Sunday and off rows

### DIFF
--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -526,9 +526,9 @@
 				weeks.empty();				
 				pm.add(nm).removeClass(css.disabled); 
 				
-				// !begin === "sunday"
-				for (var j = !begin ? -7 : 0, a, num; j < (!begin ? 35 : 42); j++) { 
-					
+				var last_day = new Date(year, month+1, 0).getDate();
+				var remaining = Math.ceil((last_day + begin) / 7) * 7;
+				for (var j = 0, a, num; j < remaining; j++) {
 					a = $("<a/>");
 					
 					if (j % 7 === 0) {

--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -587,7 +587,7 @@
 
 				// sunday
 				if (css.sunday) {
-					weeks.find(css.week).each(function() {
+					weeks.find("." + css.week).each(function() {
 						var beg = conf.firstDay ? 7 - conf.firstDay : 0;
 						$(this).children().slice(beg, beg + 1).addClass(css.sunday);		
 					});	


### PR DESCRIPTION
  Hi!

I have two patches for dateinput.js.
- Fixing the sunday selector, because $("sunday") was used instead of $(".sunday")
- There were months (2010 nov), when full weeks were displayed from the next or previous month.

Nucc
