### PR TITLE
Need an extra afterChange event for dateinput

### DIFF
--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -277,7 +277,7 @@
 			
 			
 			// change
-			e = e || $.Event("api");
+			e || (e = $.Event("api"));
 			e.type = "change";
 			
 			fire.trigger(e, [date]); 
@@ -285,6 +285,10 @@
 			
 			// formatting			
 			input.val(format(date, conf.format, conf.lang));
+			
+			// onAfterChange
+			e.type = "onAfterChange";
+			fire.trigger(e, [date]);
 			
 			// store value into input
 			input.data("date", date);


### PR DESCRIPTION
Due to this issue: https://github.com/jquerytools/jquerytools/issues/issue/292

I think it's prudent to add an onAfterChange event for the dateinput.  I can only assume there's a reason why the change event is triggered _before_ the value is set, and as such I've added onAfterChange.  This allows users to do something with the input after the new value has been set (ie. submit a form)
