### PR TITLE
Dateinput bug fix: clicking on hidden next/prev month button hides calendar

### DIFF
--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -371,7 +371,7 @@
 			$(document).bind("click.d", function(e) {					
 				var el = e.target;
 				
-				if (!$(el).parents("#" + css.root).length && el != input[0] && (!trigger || el != trigger[0])) {
+				if (!(el.id == css.root || $(el).parents("#" + css.root).length) && el != input[0] && (!trigger || el != trigger[0])) {
 					self.hide(e);
 				}
 				


### PR DESCRIPTION
If the next/prev month buttons are hidden via visibility: hidden and the user clicks on the area where the button is after it's been hidden, the click event's target ends up being the root node.  The code that checks for this expects the event to be a child of the root node instead of the root node itself, so this patch just adds a check for this.
