### PR TITLE
Issue #87 - fix positioning of elements inside hidden scrollables containing images

### DIFF
--- a/src/scrollable/scrollable.js
+++ b/src/scrollable/scrollable.js
@@ -228,9 +228,31 @@
 				}
 				
 			});
-			
+
 			// seek over the cloned item
-			self.seekTo(0, 0, function() {});
+
+			// if the scrollable is hidden the calculations for seekTo position
+			// will be incorrect (eg, if the scrollable is inside an overlay).
+			// ensure the elements are shown, calculate the correct position,
+			// then re-hide the elements. This must be done synchronously to
+			// prevent the hidden elements being shown to the user.
+
+			// See: https://github.com/jquerytools/jquerytools/issues#issue/87
+
+			var hidden_parents = root.parents().add(root).filter(function () {
+				if ($(this).css('display') === 'none') {
+					return true;
+				}
+			});
+			if (hidden_parents.length) {
+				hidden_parents.show();
+				self.seekTo(0, 0, function() {});
+				hidden_parents.hide();
+			}
+			else {
+				self.seekTo(0, 0, function() {});
+			}
+
 		}
 		
 		// next/prev buttons


### PR DESCRIPTION
This issue regards scrollables inside an overlay, when circular is set to true the position of the first element is incorrect due to the prepended cloned element.

Normally this works fine, but when the scrollable is hidden the size of the cloned element is sometimes incorrectly calculated, meaning the scrollable displays cloned element at the start instead of the first 'real' element to its right.

@tipiirai please let me know if you want to continue receiving pull requests for these, but they seem like a convenient way for you to review my changes, at least until I'm more familiar with the code.
