### PR TITLE
fix unexpected behavior when calling $('my_selector').tooltip() a second time on altered elements

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -316,10 +316,6 @@
 	
 	// jQuery plugin implementation
 	$.fn.tooltip = function(conf) {
-		
-		// return existing instance
-		var api = this.data("tooltip");
-		if (api) { return api; }
 
 		conf = $.extend(true, {}, $.tools.tooltip.conf, conf);
 		
@@ -329,9 +325,12 @@
 		}
 		
 		// install tooltip for each entry in jQuery object
+		// that is not an existing instance
 		this.each(function() {
-			api = new Tooltip($(this), conf); 
-			$(this).data("tooltip", api); 
+			if ( $(this).data("tooltip")===null){
+			    api = new Tooltip($(this), conf);
+			    $(this).data("tooltip", api);
+			};
 		});
 		
 		return conf.api ? api: this;		 


### PR DESCRIPTION
check each tooltip for existence (fixes issue 349)
rather than checking if any tooltips already exist.
this way tooltips on some elements that are reloaded via
ajax calls will continue working. the previous code would
assume all tooltips still exist if _any_ of the tooltips still
exist -- even if some of them no longer exist. now, part of a
page may be changed and can have new tooltips created instead
of only the ones for elements that did not change.

resolves: https://github.com/jquerytools/jquerytools/issues/349

Signed-off-by: Adam Mckaig adam.mckaig@gmail.com
