### PR TITLE
Prevent default Firefox 4 validation

### DIFF
--- a/src/validator/validator.js
+++ b/src/validator/validator.js
@@ -259,6 +259,9 @@
 	
 	function Validator(inputs, form, conf) {		
 		
+		// Prevent default Firefox validation
+		form.attr("novalidate", "novalidate");
+
 		// private variables
 		var self = this, 
 			 fire = form.add(self);


### PR DESCRIPTION
Small fix to prevent default Firefox 4 validation
