### PR TITLE
Jquery 1.4.3 history bug fixed

### DIFF
--- a/src/toolbox/toolbox.history.js
+++ b/src/toolbox/toolbox.history.js
@@ -34,7 +34,7 @@
 							 h = idoc.location.hash;
 					
 						if (hash !== h) {						
-							$.event.trigger("hash", h);
+							$('body').trigger("hash", h);
 						}
 					}, 100);
 					
@@ -47,7 +47,7 @@
 				setInterval(function() {
 					var h = location.hash;
 					if (h !== hash) {
-						$.event.trigger("hash", h);
+						$('body').trigger("hash", h);
 					}						
 				}, 100);
 			}
@@ -80,7 +80,7 @@
 	} 
 		 
 	// global histroy change listener
-	$(window).bind("hash", function(e, h)  { 
+	$("body").bind("hash", function(e, h)  { 
 		if (h) {
 			links.filter(function() {
 			  var href = $(this).attr("href");


### PR DESCRIPTION
If you try to use jQuery 1.4.3 instead of 1.4.2 (for instance if you want to use an external library that relies upon it) you will be unable to use history: true in conjunction with effect: "ajax" when using JQuery Tools Tabs because $.event seems to have changed in this point upgrade.

Discussion from the forum about this issue: http://flowplayer.org/tools/forum/25/51221
