### PR TITLE
Validation message position per element

### DIFF
--- a/src/validator/validator.js
+++ b/src/validator/validator.js
@@ -42,6 +42,12 @@
 			messageClass: 'error',		// error message element's class name
 			offset: [0, 0], 
 			position: 'center right',
+			elementPosition: function(element) {
+				return null;
+			}, // callback for handling positioning of specified elements
+			elementOffset: function(element) {
+				return null;
+			}, // callback for handing custom offsets per element
 			singleError: false, 			// validate all inputs at once
 			speed: 'normal'				// message's fade-in speed			
 		},
@@ -99,13 +105,33 @@
 		
 		// get origin top/left position 
 		var top = trigger.offset().top, 
-			 left = trigger.offset().left,	 
-			 pos = conf.position.split(/,?\s+/),
-			 y = pos[0],
-			 x = pos[1];
+			left = trigger.offset().left,	 
+			pos = null,
+			confPos = conf.position,
+			offset = null,
+			confOffset = conf.offset,
+			y,
+			x;
+
+		if (conf.elementPosition !== null) {
+			pos = conf.elementPosition(trigger);
+		} 
+		if (pos === null) {
+			pos = confPos;
+		}
+		pos = pos.split(/,?\s+/);
+		y = pos[0];
+		x = pos[1];
+
+		if (conf.elementOffset !== null) {
+			offset = conf.elementOffset(trigger);
+		}
+		if (offset === null) {
+			offset = confOffset;
+		}
 		
-		top  -= el.outerHeight() - conf.offset[0];
-		left += trigger.outerWidth() + conf.offset[1];
+		top  -= el.outerHeight() - offset[0];
+		left += trigger.outerWidth() + offset[1];
 		
 		
 		// iPad position fix
@@ -121,7 +147,15 @@
 		// adjust X
 		var width = trigger.outerWidth();
 		if (x == 'center') 	{ left -= (width  + el.outerWidth()) / 2; }
-		if (x == 'left')  	{ left -= width; }	 
+		if (x == 'left')  	{ left -= width + el.outerWidth(); }	 
+
+		// Make sure that the element is still visible
+		if (left <= 0) {
+			left = 0;
+		}
+		if (top <= 0) {
+			top = 0;
+		}
 		
 		return {top: top, left: left};
 	}	

--- a/src/validator/validator.js
+++ b/src/validator/validator.js
@@ -42,10 +42,10 @@
 			messageClass: 'error',		// error message element's class name
 			offset: [0, 0], 
 			position: 'center right',
-			elementPosition: function(element) {
+			elementPosition: function(trigger, errorElement) {
 				return null;
 			}, // callback for handling positioning of specified elements
-			elementOffset: function(element) {
+			elementOffset: function(trigger, errorElement) {
 				return null;
 			}, // callback for handing custom offsets per element
 			singleError: false, 			// validate all inputs at once
@@ -114,7 +114,7 @@
 			x;
 
 		if (conf.elementPosition !== null) {
-			pos = conf.elementPosition(trigger);
+			pos = conf.elementPosition(trigger, el);
 		} 
 		if (pos === null) {
 			pos = confPos;
@@ -124,7 +124,7 @@
 		x = pos[1];
 
 		if (conf.elementOffset !== null) {
-			offset = conf.elementOffset(trigger);
+			offset = conf.elementOffset(trigger, el);
 		}
 		if (offset === null) {
 			offset = confOffset;

--- a/test/validator/validator.htm
+++ b/test/validator/validator.htm
@@ -30,7 +30,7 @@ div.error {
 								/>
 	</p>
 	<p>
-		date <input type="date" title="Use format yyyy-mm-dd" name="day" min="-40" required="true" />
+		date <input data-position="center left" type="date" title="Use format yyyy-mm-dd" name="day" min="-40" required="true" />
 	</p>
 	
 	<p>
@@ -67,7 +67,17 @@ $.tools.validator.fn("[type=range]", "Please supply a value between $1 and $2", 
 	
 });
 */
-var api = $("form").validator({attrPrefix: null, grouped: true}).bind("onBeforeValidate", function()  {
+var api = $("form").validator({
+    attrPrefix: null,
+    grouped: true,
+    elementPosition: function(el) {
+        var dataPosition = $(el).attr('data-position');
+        if (typeof dataPosition === 'undefined') {
+            dataPosition = null;
+        }
+        return dataPosition;
+    }
+}).attr('novalidate', 'novalidate').bind("onBeforeValidate", function()  {
 	console.info("BEFORE", this, arguments);
 	
 }).data("validator");


### PR DESCRIPTION
Hi :-) First of all thanks to the great work on jquery.tools. I'm currently trying to use jquery.tools.validator for a larger project but needed to make some small modifications to make it work for some of the requirements.

In my experience it is quite common to have multiple input fields in one line for instance for City and Postalcode in a registration form. In order to prevent validation messages from overlapping each other it would be nice if jquery.tools.validator also supported some kind of positioning option for each input field. One example could be the handling of optional "data-position"  and "data-offset" attributes associated with an input element.

I've written a rather basic implementation for this that offers two optional callbacks (elementPosition and elementOffset) with the validator configuration. Each callback receives the input node as well as the message div as arguments and should return values similar to the "position" and "offset" settings or null if the respective  "global" setting should be used.

Would something like this be worth pulling into the master repo?

The two commits also contain a slightly different handling for the "left" positioning handling. The original implementation didn't take the width of the message itself into account so depending on the message the input field was no longer visible.
