### PR TITLE
Prevent bubbling on previous/next links

### DIFF
--- a/src/scrollable/scrollable.js
+++ b/src/scrollable/scrollable.js
@@ -256,8 +256,8 @@
 		}
 		
 		// next/prev buttons
-		var prev = find(root, conf.prev).click(function() { self.prev(); }),
-			 next = find(root, conf.next).click(function() { self.next(); }); 
+		var prev = find(root, conf.prev).click(function(e) { e.stopPropagation(); self.prev(); }),
+			 next = find(root, conf.next).click(function(e) { e.stopPropagation(); self.next(); }); 
 		
 		if (!conf.circular) {
 			self.onBeforeSeek(function(e, i) {


### PR DESCRIPTION
I think it's safe to disable bubbling on these buttons since I can't think of a use for bubbling on Previous/Next buttons.
