### PR TITLE
Tweaks to allow the expose plugin to work when you are rapidly un/exposing something

### DIFF
--- a/src/toolbox/toolbox.expose.js
+++ b/src/toolbox/toolbox.expose.js
@@ -62,120 +62,125 @@
 		if (fn) { return fn.call($.mask); }
 	}
 	
-	var mask, exposed, loaded, config, overlayIndex;		
+	var mask, exposed, loadStatus, config, overlayIndex;		
 	
 	
 	$.mask = {
 		
 		load: function(conf, els) {
-			
 			// already loaded ?
-			if (loaded) { return this; }			
-			
-			// configuration
-			if (typeof conf == 'string') {
-				conf = {color: conf};	
-			}
-			
-			// use latest config
-			conf = conf || config;
-			
-			config = conf = $.extend($.extend({}, tool.conf), conf);
-
-			// get the mask
-			mask = $("#" + conf.maskId);
-				
-			// or create it
-			if (!mask.length) {
-				mask = $('<div/>').attr("id", conf.maskId);
-				$("body").append(mask);
-			}
-			
-			// set position and dimensions 			
-			var size = viewport();
-				
-			mask.css({				
-				position:'absolute', 
-				top: 0, 
-				left: 0,
-				width: size[0],
-				height: size[1],
-				display: 'none',
-				opacity: conf.startOpacity,					 		
-				zIndex: conf.zIndex 
-			});
-			
-			if (conf.color) {
-				mask.css("backgroundColor", conf.color);	
-			}			
-			
-			// onBeforeLoad
-			if (call(conf.onBeforeLoad) === false) {
+			if (loadStatus == 'full') {
 				return this;
 			}
-			
-			// esc button
-			if (conf.closeOnEsc) {						
-				$(document).bind("keydown.mask", function(e) {							
-					if (e.keyCode == 27) {
-						$.mask.close(e);	
-					}		
-				});			
+			if (!loadStatus) {
+
+				// configuration
+				if (typeof conf == 'string') {
+					conf = {color: conf};
+				}
+
+				// use latest config
+				conf = conf || config;
+
+				config = conf = $.extend($.extend({}, tool.conf), conf);
+
+				// get the mask
+				mask = $("#" + conf.maskId);
+
+				// or create it
+				if (!mask.length) {
+					mask = $('<div/>').attr("id", conf.maskId);
+					$("body").append(mask);
+				}
+
+				// set position and dimensions
+				var size = viewport();
+
+				mask.css({
+					position:'absolute',
+					top: 0,
+					left: 0,
+					width: size[0],
+					height: size[1],
+					display: 'none',
+					opacity: conf.startOpacity,
+					zIndex: conf.zIndex
+				});
+
+				if (conf.color) {
+					mask.css("backgroundColor", conf.color);
+				}
+
+				// onBeforeLoad
+				if (call(conf.onBeforeLoad) === false) {
+					return this;
+				}
+
+				// esc button
+				if (conf.closeOnEsc) {
+					$(document).bind("keydown.mask", function(e) {
+						if (e.keyCode == 27) {
+							$.mask.close(e);
+						}
+					});
+				}
+
+				// mask click closes
+				if (conf.closeOnClick) {
+					mask.bind("click.mask", function(e)  {
+						$.mask.close(e);
+					});
+				}
+
+				// resize mask when window is resized
+				$(window).bind("resize.mask", function() {
+					$.mask.fit();
+				});
+
+				// exposed elements
+				if (els && els.length) {
+
+					overlayIndex = els.eq(0).css("zIndex");
+
+					// make sure element is positioned absolutely or relatively
+					$.each(els, function() {
+						var el = $(this);
+						if (!/relative|absolute|fixed/i.test(el.css("position"))) {
+							el.css("position", "relative");
+						}
+					});
+
+					// make elements sit on top of the mask
+					exposed = els.css({ zIndex: Math.max(conf.zIndex + 1, overlayIndex == 'auto' ? 0 : overlayIndex)});
+				}
 			}
 			
-			// mask click closes
-			if (conf.closeOnClick) {
-				mask.bind("click.mask", function(e)  {
-					$.mask.close(e);		
-				});					
-			}			
-			
-			// resize mask when window is resized
-			$(window).bind("resize.mask", function() {
-				$.mask.fit();
-			});
-			
-			// exposed elements
-			if (els && els.length) {
-				
-				overlayIndex = els.eq(0).css("zIndex");
-
-				// make sure element is positioned absolutely or relatively
-				$.each(els, function() {
-					var el = $(this);
-					if (!/relative|absolute|fixed/i.test(el.css("position"))) {
-						el.css("position", "relative");		
-					}					
-				});
-			 
-				// make elements sit on top of the mask
-				exposed = els.css({ zIndex: Math.max(conf.zIndex + 1, overlayIndex == 'auto' ? 0 : overlayIndex)});			
-			}	
-			
 			// reveal mask
-			mask.css({display: 'block'}).fadeTo(conf.loadSpeed, conf.opacity, function() {
+			mask.css({display: 'block'}).stop().fadeTo(conf.loadSpeed, conf.opacity, function() {
 				$.mask.fit(); 
 				call(conf.onLoad);
-				loaded = "full";
+				loadStatus = "full";
 			});
 			
-			loaded = true;			
+			loadStatus = true;			
 			return this;				
 		},
 		
 		close: function() {
-			if (loaded) {
+			if (loadStatus) {
 				
 				// onBeforeClose
 				if (call(config.onBeforeClose) === false) { return this; }
 					
-				mask.fadeOut(config.closeSpeed, function()  {					
+				mask.stop().fadeOut(config.closeSpeed, function()  {
 					call(config.onClose);					
 					if (exposed) {
 						exposed.css({zIndex: overlayIndex});						
 					}				
-					loaded = false;
-				});				
+					loadStatus = false;
+				});
+
+				loadStatus = 'closing';
 				
 				// unbind various event listeners
 				$(document).unbind("keydown.mask");
@@ -187,7 +192,7 @@
 		},
 		
 		fit: function() {
-			if (loaded) {
+			if (loadStatus) {
 				var size = viewport();				
 				mask.css({width: size[0], height: size[1]});
 			}				
@@ -198,7 +203,7 @@
 		},
 		
 		isLoaded: function(fully) {
-			return fully ? loaded == 'full' : loaded;	
+			return fully ? loadStatus == 'full' : loadStatus;	
 		}, 
 		
 		getConf: function() {


### PR DESCRIPTION
I'm using the expose plugin on a navigation similar to the one on http://www2.goldmansachs.com/ and I needed to expose/ unexpose sometimes rapidly based on user's mouse movements. I did the tweaks in the attached code to enable this...
