### PR TITLE
Additional parameter scrollItems added

### DIFF
--- a/src/scrollable/scrollable.js
+++ b/src/scrollable/scrollable.js
@@ -29,6 +29,7 @@
 			mousewheel: false,
 			next: '.next',   
 			prev: '.prev', 
+                        scrollItems: 1,
 			speed: 400,
 			vertical: false,
 			touch: true,
@@ -100,11 +101,11 @@
 			},
 			
 			next: function(time) {
-				return self.move(1, time);	
+				return self.move(conf.scrollItems, time);	
 			},
 			
 			prev: function(time) {
-				return self.move(-1, time);	
+				return self.move(-conf.scrollItems, time);	
 			},
 			
 			begin: function(time) {


### PR DESCRIPTION
Additional parameter scrollItems (default value 1) added to allow to specify how many items to scroll (the feature was hardcoded to 1).
