### PR TITLE
Scrollable with one or zero items (and particularly with circular true)

### DIFF
--- a/src/scrollable/scrollable.js
+++ b/src/scrollable/scrollable.js
@@ -192,8 +192,12 @@
 			};
 		});  
 		
+		// next/prev buttons
+		var prev = find(root, conf.prev).click(function() { self.prev(); }),
+			 next = find(root, conf.next).click(function() { self.next(); });	
+		
 		// circular loop
-		if (conf.circular) {
+		if (conf.circular && self.getSize() > 1) {
 			
 			var cloned1 = self.getItems().slice(-1).clone().prependTo(itemWrap),
 				 cloned2 = self.getItems().eq(1).clone().appendTo(itemWrap);
@@ -225,13 +229,8 @@
 			
 			// seek over the cloned item
 			self.seekTo(0, 0, function() {});
-		}
-		
-		// next/prev buttons
-		var prev = find(root, conf.prev).click(function() { self.prev(); }),
-			 next = find(root, conf.next).click(function() { self.next(); });	
-		
-		if (!conf.circular && self.getSize() > 1) {
+
+		} else if (!conf.circular && self.getSize() > 1) {
 			
 			self.onBeforeSeek(function(e, i) {
 				setTimeout(function() {
@@ -245,6 +244,9 @@
 			if (!conf.initialIndex) {
 				prev.addClass(conf.disabledClass);	
 			}
+		} else { // the case where there is one or zero items
+			prev.addClass(conf.disabledClass);
+			next.addClass(conf.disabledClass);
 		}
 			
 		// mousewheel support


### PR DESCRIPTION
Having one item with circular set to true resulted in a single item
cloned and scrolling, which is not a desirable condition. Having
zero items with circular set to true resulted in an error. By
enforcing a check more similar to the one performed when circular
is false, we are able to catch this condition.

Additionally, the prev and next buttons are set to disabled in the
case of one or zero items.
