### PR TITLE
new way for calculating day of month

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,8 @@
 ================================
 
 jQuery Tools is a collection of the most important user-interface components for modern websites. Used by large sites all over the world.
+
+##Contributing
+
+Please issue pull requests to the [dev branch](https://github.com/jquerytools/jquerytools/tree/dev).  
+This is where active development takes place, we then merge changes into master for releases


### PR DESCRIPTION
bufix for function dayAm in dateinput.js, dosent work in firefox 4.0.1 for a specific date (May 1947)
