### PR TITLE
flashembed: no way to detect root element in onFail handler

### DIFF
--- a/src/toolbox/toolbox.flashembed.js
+++ b/src/toolbox/toolbox.flashembed.js
@@ -212,6 +212,28 @@
 	var VERSION = f.getVersion(); 
 	
 	function Flash(root, opts, conf) {  
+		
+		// API methods for callback
+		extend(this, {
+				
+			getRoot: function() {
+				return root;	
+			},
+			
+			getOptions: function() {
+				return opts;	
+			},
+
+			
+			getConf: function() {
+				return conf;	
+			}, 
+			
+			getApi: function() {
+				return root.firstChild;	
+			}
+			
+		}); 
 	                                                
 		// version is ok
 		if (f.isSupported(opts.version)) {
@@ -256,28 +278,6 @@
 		if (IE) {
 			window[opts.id] = document.getElementById(opts.id);
 		} 
-		
-		// API methods for callback
-		extend(this, {
-				
-			getRoot: function() {
-				return root;	
-			},
-			
-			getOptions: function() {
-				return opts;	
-			},
-
-			
-			getConf: function() {
-				return conf;	
-			}, 
-			
-			getApi: function() {
-				return root.firstChild;	
-			}
-			
-		}); 
 	}
 	
 	// setup jquery support


### PR DESCRIPTION
flashembed: declared methods for Flash class before doing any real work. Before the onFail callback was unable to determine some environment attributes (e.g. which root element was used for flash embedding)

see http://flowplayer.org/forum/8/67255 for further information
