### PR TITLE
Configurable offset parent

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -29,6 +29,7 @@
 			position: ['top', 'center'], 
 			offset: [0, 0],
 			relative: false,
+			offsetParent: null,
 			cancelDefault: true,
 			
 			// type to event mapping 
@@ -190,10 +191,15 @@
 					// manual tooltip
 					} else {	
 						tip = trigger.next();  
-						if (!tip.length) { tip = trigger.parent().next(); } 	 
+						if (!tip.length) { tip = trigger.parent().next(); }
+						
 					}
 					
 					if (!tip.length) { throw "Cannot find tooltip for " + trigger;	}
+					
+					if (conf.offsetParent) {
+						tip.appendTo($(conf.offsetParent));
+					}
 				} 
 			 	
 			 	if (self.isShown()) { return self; }  


### PR DESCRIPTION
Hi there,

sometimes you want to have a different offsetParent for a tooltip. I've added a new option offsetParent, that allows you to change the hardcoded offsetParent by appending the tooltip to a configured element.

Bye,

Fabrizio
