### PR TITLE
add updateParent config option in tabs

### DIFF
--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -27,7 +27,8 @@
 			rotate: false,
 			
 			// 1.2
-			history: false
+			history: false,
+			updateParent: false
 		},
 		
 		addEffect: function(name, fn) {
@@ -159,9 +160,15 @@
 				
 				// default behaviour
 				current = i;
-				tabs.removeClass(conf.current);	
-				tab.addClass(conf.current);				
+				tabs.removeClass(conf.current);
+				tab.addClass(conf.current);
 				
+				// update parent class as well
+				if (conf.updateParent) {
+				  tabs.parent().removeClass(conf.current);
+				  tab.parent().addClass(conf.current);
+				}
+
 				return self;
 			},
 			


### PR DESCRIPTION
Hi,

I added an updateParent config option in tabs, once the tab is selected, its parent will also have the "current" class attribute.  Current css specification doesn't have a selector to select one tag's parent, so this option will be handy if someone wants to style the parent tag of the current selected tab as well.

Thanks for the great jquery plugin.
