### PR TITLE
Added changes to calculate position of tooltip on the basis of inline element offset.

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -29,8 +29,9 @@
 			position: ['top', 'center'], 
 			offset: [0, 0],
 			relative: false,
+			calculateInlineOffset: false,
 			cancelDefault: true,
-			
+
 			// type to event mapping 
 			events: {
 				def: 			"mouseenter,mouseleave",
@@ -42,6 +43,7 @@
 			// 1.2
 			layout: '<div/>',
 			tipClass: 'tooltip'
+
 		},
 		
 		addEffect: function(name, loadFn, hideFn) {
@@ -85,6 +87,17 @@
 		var top = conf.relative ? trigger.position().top : trigger.offset().top, 
 			 left = conf.relative ? trigger.position().left : trigger.offset().left,
 			 pos = conf.position[0];
+		
+		//If relative is false and calculateInlineOffset flag is on then only go for it.
+		if (!conf.relative && conf.calculateInlineOffset) {
+			//Get the actual inline offset of triggered elem
+			var iOffset = $(trigger).inlineOffset();
+			
+			//If element is spans multilines then compare the left positions.  
+			if (left < iOffset.left){
+				left = iOffset.left;
+			}
+		}
 
 		top  -= tip.outerHeight() - conf.offset[0];
 		left += trigger.outerWidth() + conf.offset[1];
@@ -336,8 +349,15 @@
 		
 		return conf.api ? api: this;		 
 	};
+	
+	//Adding jQuery plugin to calculate the inline offset of elem
+	$.fn.inlineOffset = function() {
+	    var el = $('<i/>').css('display','inline').insertBefore(this[0]);
+	    var pos = el.offset();
+	    el.remove();
+	    return pos;
+	};
 		
 }) (jQuery);
 
 		
-


### PR DESCRIPTION
Hi, For Tooltip, Position calculation was calculated wrong, if a span element is spread to multiline. I used inline element to fix this.

If we enable  config "calculateInlineOffset" ( true ) then it will calculated on the basis of an inline element.
