### PR TITLE
Fixes from broken calendar next month on days like July 31st

### DIFF
--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -618,7 +618,11 @@
 			},
 			
 			addMonth: function(amount) {
-				return this.setValue(currYear, currMonth + (amount || 1), currDay);	
+				var targetMonth        = currMonth + (amount || 1);
+				var lastDayTargetMonth = dayAm(currYear, targetMonth);
+				var targetDay          = currDay <= lastDayTargetMonth ? currDay : lastDayTargetMonth;
+				
+				return this.setValue(currYear, targetMonth, targetDay);
 			},
 			
 			addYear: function(amount) {


### PR DESCRIPTION
Fixed addMonth to handle moving between months with different numbers of days more correctly.

Previously, if the month being moved to had more days than the month being moved from, it would attempt to set an impossible date, E.G. July 31 -> August 31 (august has only 30 days). Now, it will move from July 31 -> Aug 30.
