### PR TITLE
Fixes from broken calendar next month on days like July 31st 

### DIFF
--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -618,7 +618,11 @@
 			},
 			
 			addMonth: function(amount) {
-				return this.setValue(currYear, currMonth + (amount || 1), currDay);	
+				var targetMonth        = currMonth + (amount || 1);
+				var lastDayTargetMonth = dayAm(currYear, targetMonth);
+				var targetDay          = currDay <= lastDayTargetMonth ? currDay : lastDayTargetMonth;
+				
+				return this.setValue(currYear, targetMonth, targetDay);
 			},
 			
 			addYear: function(amount) {

--- a/src/scrollable/scrollable.js
+++ b/src/scrollable/scrollable.js
@@ -192,8 +192,12 @@
 			};
 		});  
 		
+		// next/prev buttons
+		var prev = find(root, conf.prev).click(function() { self.prev(); }),
+			 next = find(root, conf.next).click(function() { self.next(); });	
+		
 		// circular loop
-		if (conf.circular) {
+		if (conf.circular && self.getSize() > 1) {
 			
 			var cloned1 = self.getItems().slice(-1).clone().prependTo(itemWrap),
 				 cloned2 = self.getItems().eq(1).clone().appendTo(itemWrap);
@@ -225,13 +229,8 @@
 			
 			// seek over the cloned item
 			self.seekTo(0, 0, function() {});
-		}
-		
-		// next/prev buttons
-		var prev = find(root, conf.prev).click(function() { self.prev(); }),
-			 next = find(root, conf.next).click(function() { self.next(); });	
-		
-		if (!conf.circular && self.getSize() > 1) {
+
+		} else if (!conf.circular && self.getSize() > 1) {
 			
 			self.onBeforeSeek(function(e, i) {
 				setTimeout(function() {
@@ -245,6 +244,9 @@
 			if (!conf.initialIndex) {
 				prev.addClass(conf.disabledClass);	
 			}
+		} else { // the case where there is one or zero items
+			prev.addClass(conf.disabledClass);
+			next.addClass(conf.disabledClass);
 		}
 			
 		// mousewheel support

--- a/src/scrollable/scrollable.js
+++ b/src/scrollable/scrollable.js
@@ -192,12 +192,8 @@
 			};
 		});  
 		
-		// next/prev buttons
-		var prev = find(root, conf.prev).click(function() { self.prev(); }),
-			 next = find(root, conf.next).click(function() { self.next(); });	
-		
 		// circular loop
-		if (conf.circular && self.getSize() > 1) {
+		if (conf.circular) {
 			
 			var cloned1 = self.getItems().slice(-1).clone().prependTo(itemWrap),
 				 cloned2 = self.getItems().eq(1).clone().appendTo(itemWrap);
@@ -229,8 +225,13 @@
 			
 			// seek over the cloned item
 			self.seekTo(0, 0, function() {});
-
-		} else if (!conf.circular && self.getSize() > 1) {
+		}
+		
+		// next/prev buttons
+		var prev = find(root, conf.prev).click(function() { self.prev(); }),
+			 next = find(root, conf.next).click(function() { self.next(); });	
+		
+		if (!conf.circular && self.getSize() > 1) {
 			
 			self.onBeforeSeek(function(e, i) {
 				setTimeout(function() {
@@ -244,9 +245,6 @@
 			if (!conf.initialIndex) {
 				prev.addClass(conf.disabledClass);	
 			}
-		} else { // the case where there is one or zero items
-			prev.addClass(conf.disabledClass);
-			next.addClass(conf.disabledClass);
 		}
 			
 		// mousewheel support


### PR DESCRIPTION
This is the same as https://github.com/jquerytools/jquerytools/pull/475 but target into the dev branch per bradrobertson's recommendation. 

Fixed addMonth to handle moving between months with different numbers of days more correctly.

Previously, if the month being moved to had more days than the month being moved from, it would attempt to set an impossible date, E.G. July 31 -> August 31 (august has only 30 days). Now, it will move from July 31 -> Aug 30.
