### PR TITLE
Trigger elements toggle showing/hiding calendar instead of only showing

### DIFF
--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -256,7 +256,7 @@
 				
 		// trigger icon
 		if (conf.trigger) {
-			trigger = $("<a/>").attr("href", "#").addClass(css.trigger).click(function(e)  {
+			trigger = $("<a/>").attr("href", "#").addClass(css.trigger).bind("click.t", function(e)  {
 				self.show();
 				return e.preventDefault();
 			}).insertAfter(input);	
@@ -380,6 +380,15 @@
 				}
 				
 			}); 
+
+			if (conf.trigger) {
+				input.siblings("." + conf.css.trigger)
+					.unbind("click.t")
+					.bind("click.t", function(e) {
+						self.hide(e);
+						e.preventDefault();
+					});
+			}
 		}
 //}}}
 
@@ -659,6 +668,15 @@
 					
 					$(document).unbind("click.d").unbind("keydown.d");
 					
+					if (conf.trigger) {
+						input.siblings("." + conf.css.trigger)
+							.unbind("click.t")
+							.bind("click.t", function(e) {
+								self.show(e);
+								e.preventDefault();
+							});
+					}
+
 					// cancelled ?
 					if (e.isDefaultPrevented()) { return; }
 					

--- a/test/dateinput/customized.htm
+++ b/test/dateinput/customized.htm
@@ -24,8 +24,11 @@ $(":date:eq(1)").dateinput({
   firstDay: 1,
   speed: 'fast',
   selectors: false,
-  yearRange: [-75, -10]
+  yearRange: [-75, -10],
+  trigger: true
 });
+
+$("a.caltrigger").text("trigger");
 </script>
 
 


### PR DESCRIPTION
Now that #205 is fixed, there was one remaining piece of local boilerplate that I use in every project related to dateinput pickers being dismissed when I expect them to be -- since there's some activity stirring up on jQuery Tools these days, thought it might be a good time to submit a pull request to fix that :-)
