### PR TITLE
bug fix

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -235,7 +235,7 @@
 				// tooltip events       
 				var event = conf.events.tooltip.split(/,\s*/);
 
-				if (!tip.data("__set")) {
+				if (conf.tip || !tip.data("__set")) {
 					
 					tip.bind(event[0], function() { 
 						clearTimeout(timer);


### PR DESCRIPTION
fixed the tooltip not showing up when instantiated on the similar elements for eg table tr In this case, the tooltip only shows up on the first tr, after that it flickers and disappears. This issus has been fixed.
