### PR TITLE
Added support for enclosing tooltip inside trigger element (2nd try)

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -189,7 +189,8 @@
 
 					// manual tooltip
 					} else {	
-						tip = trigger.next();  
+						tip = trigger.find('.' + conf.tipClass);
+						if (!tip.length) { tip = trigger.next(); }
 						if (!tip.length) { tip = trigger.parent().next(); } 	 
 					}
 					

--- a/test/tooltip/index.html
+++ b/test/tooltip/index.html
@@ -104,6 +104,39 @@ body {
 	
 </div>
 
+<div id="manual-enclosed" class="test">
+
+	<h3>Manual enclosed tooltip</h3>
+		
+	<table>
+		<tbody>
+			<tr>
+				<td class="trigger">
+					trigger 1
+					<div class="tooltip">Manual enclosed #1</div>
+				</td>
+				<td class="trigger">
+					trigger 2
+					<div class="tooltip">Manual enclosed #2</div>
+				</td>
+				<td class="trigger">
+					trigger 3
+					<div class="tooltip">Manual enclosed #3</div>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+	
+	<script>
+		$("#manual-enclosed td").tooltip({ 
+			delay: 300, 
+			predelay: 0,
+			effect: 'fade'
+		});
+	</script>
+	
+</div>
+
 <div id="same" class="test">
 
 	<h3>Same tip element</h3>


### PR DESCRIPTION
Added possibility to enclose tooltip element inside trigger element (e.g. for table cells), incl. test.
Use like this:

<pre><code>&lt;table&gt;
    ...
    &lt;td&gt;
        some table cell text
        &lt;div class="tooltip"&gt;my cell specific tooltip&lt;/div&gt;
    &lt;/td&gt;
    ...
&lt;table&gt;
</code></pre>
