### PR TITLE
Repeated XHR request issue

### DIFF
--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -22,7 +22,7 @@
 			onBeforeClick: null,
 			onClick: null, 
 			effect: 'default',
-			initialIndex: 0,			
+			//initialIndex: 0,
 			event: 'click',
 			rotate: false,
 			


### PR DESCRIPTION
On referring to ticket https://github.com/jquerytools/jquerytools/pull/287

http://flowplayer.org/tools/demos/tabs/ajax-history.html#ajax3.htm has 2 ajax GET requests instead of 1 request, for issue need to remove `initialIndex: 0,`.

The issue works fine for all browsers except IE6 and IE7 where it cases null GET request for http://flowplayer.org/tools/demos/tabs/ajax-history.html, what is already a new bug.
