### PR TITLE
Fixes problems with next month and previous months disabling incorrectly

### DIFF
--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -510,6 +510,8 @@
 				var tmp = new Date(year, month, 1 - conf.firstDay), begin = tmp.getDay(),
 					 days = dayAm(year, month),
 					 prevDays = dayAm(year, month - 1),
+					 firstDay = new Date(year, month, 1),
+					 lastDay = new Date(year, month, days),
 					 week;	 
 				
 				// selectors
@@ -543,7 +545,15 @@
 					 
 				// populate weeks
 				weeks.empty();				
-				pm.add(nm).removeClass(css.disabled); 
+				pm.add(nm).removeClass(css.disabled);
+				
+				if (max && lastDay > max) {
+					nm.addClass(css.disabled);
+				}
+				
+				if (min && firstDay < min) {
+					pm.addClass(css.disabled);
+				}
 				
 				// !begin === "sunday"
 				for (var j = !begin ? -7 : 0, a, num; j < (!begin ? 35 : 42); j++) { 
@@ -581,11 +591,11 @@
 					
 					// disabled
 					if (min && date < min) {
-						a.add(pm).addClass(css.disabled);						
+						a.addClass(css.disabled);						
 					}
 					
 					if (max && date > max) {
-						a.add(nm).addClass(css.disabled);						
+						a.addClass(css.disabled);
 					}
 					
 					a.attr("href", "#" + num).text(num).data("date", date);					

--- a/src/toolbox/toolbox.expose.js
+++ b/src/toolbox/toolbox.expose.js
@@ -68,8 +68,10 @@
 	$.mask = {
 		
 		load: function(conf, els) {
-			
-			// already loaded ?
+			// must halt animation on close or a closing mask will have loaded == true
+			if (mask) {
+				mask.stop(true,true);
+			}
 			if (loaded) { return this; }			
 			
 			// configuration


### PR DESCRIPTION
This pull request is was asked for by alibby251. My previous pull request was at https://github.com/jquerytools/jquerytools/pull/517.

If there is a minimum set, and the minimum occurs after a day in the css.off days at the beginning of the month, then the prev button is disabled. If there is a maximum set, and the maximum _day_ value is before the current _day_ value (10/28 max, 9/27 current). Then it improperly disables the maximum.

JSFiddle Illustration - http://jsfiddle.net/vD4x3/1/

In addition, I moved the determination of the nm or pm outside of the primary days loop, since previously we were effectively calling addClass() 0-60 times more than necessary and on the nm/pm selectors.

This bug fix also fixes an error in my previous pull request. Please disregard pull 517 and only use this one.
