### PR TITLE
Added support for close buttons in remote-loaded content

### DIFF
--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -251,22 +251,16 @@
 		});
 		
 		// close button
-		// selector set?
         	if(!conf.close) {
-        		// set default one: ".close"
             		conf.close = ".close";
         	}
         	
-        	// should be created? 
         	if(this.getClosers().length == 0) {
-        		// prepend with default one
             		overlay.prepend($('<a class="close"></a>'));
         	}
-        	// delegate event now and in future
-        	// root element is our overlay and
-        	// it will work even for future-loaded overlay content
+        	
         	overlay.delegate(conf.close, 'click',function(e) {
-			self.close(e);  
+			self.close(e); 
 		});	
 		
 		// autoload

--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -74,8 +74,7 @@
 		// private variables
 		var self = this,
 			 fire = trigger.add(self),
-			 w = $(window), 
-			 closers,            
+			 w = $(window),         
 			 overlay,
 			 opened,
 			 maskConf = $.tools.expose && (conf.mask || conf.expose),
@@ -221,7 +220,8 @@
 			},
 			
 			getClosers: function() {
-				return closers;	
+				// find closers dynamically for remote-loaded content
+				return overlay.find(conf.close);
 			},			
 
 			isOpened: function()  {
@@ -251,14 +251,21 @@
 		});
 		
 		// close button
-		closers = overlay.find(conf.close || ".close");		
-		
-		if (!closers.length && !conf.close) {
-			closers = $('<a class="close"></a>');
-			overlay.prepend(closers);	
-		}		
-		
-		closers.click(function(e) { 
+		// selector set?
+        	if(!conf.close) {
+        		// set default one: ".close"
+            		conf.close = ".close";
+        	}
+        	
+        	// should be created? 
+        	if(this.getClosers().length == 0) {
+        		// prepend with default one
+            		overlay.prepend($('<a class="close"></a>'));
+        	}
+        	// delegate event now and in future
+        	// root element is our overlay and
+        	// it will work even for future-loaded overlay content
+        	overlay.delegate(conf.close, 'click',function(e) {
 			self.close(e);  
 		});	
 		

--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -259,7 +259,7 @@
             		overlay.prepend($('<a class="close"></a>'));
         	}
         	
-        	overlay.delegate(conf.close, 'click',function(e) {
+        	overlay.undelegate(conf.close,'click.overlay').delegate(conf.close, 'click.overlay',function(e) {
 			self.close(e); 
 		});	
 		


### PR DESCRIPTION
Now it is possible to define closers in remote loaded content without addiditional event handlers: overlay will delegate handler automatically using jquery.delegate
