### PR TITLE
Fix for tooltip positioning on inline elements which are spread over multiple lines

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -30,8 +30,9 @@
 			position: ['top', 'center'], 
 			offset: [0, 0],
 			relative: false,
+			calculateInlineOffset: false,
 			cancelDefault: true,
-			
+
 			// type to event mapping 
 			events: {
 				def: 			"mouseenter,mouseleave",
@@ -43,6 +44,7 @@
 			// 1.2
 			layout: '<div/>',
 			tipClass: 'tooltip'
+
 		},
 		
 		addEffect: function(name, loadFn, hideFn) {
@@ -99,6 +101,17 @@
 		var top = conf.relative ? trigger.position().top : trigger.offset().top, 
 			 left = conf.relative ? trigger.position().left : trigger.offset().left,
 			 pos = conf.position[0];
+		
+		//If relative is false and calculateInlineOffset flag is on then only go for it.
+		if (!conf.relative && conf.calculateInlineOffset) {
+			//Get the actual inline offset of triggered elem
+			var iOffset = $(trigger).inlineOffset();
+			
+			//If element is spans multilines then compare the left positions.  
+			if (left < iOffset.left){
+				left = iOffset.left;
+			}
+		}
 
 		top  -= tip.outerHeight() - conf.offset[0];
 		left += trigger.outerWidth() + conf.offset[1];
@@ -351,8 +364,15 @@
 		
 		return conf.api ? api: this;		 
 	};
+	
+	//Adding jQuery plugin to calculate the inline offset of elem
+	$.fn.inlineOffset = function() {
+	    var el = $('<i/>').css('display','inline').insertBefore(this[0]);
+	    var pos = el.offset();
+	    el.remove();
+	    return pos;
+	};
 		
 }) (jQuery);
 
 		
-

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -30,7 +30,7 @@
 			position: ['top', 'center'], 
 			offset: [0, 0],
 			relative: false,
-			calculateInlineOffset: false,
+			calculateInlineOffset: false, //If need to handle multilines inline elements
 			cancelDefault: true,
 
 			// type to event mapping 
@@ -93,48 +93,53 @@
 	};   
 
 		
-	/* calculate tip position relative to the trigger */  	
-	function getPosition(trigger, tip, conf) {	
+	/* calculate tip position relative to the trigger */    
+	function getPosition(trigger, tip, conf) {  
 
-		
-		// get origin top/left position 
-		var top = conf.relative ? trigger.position().top : trigger.offset().top, 
-			 left = conf.relative ? trigger.position().left : trigger.offset().left,
-			 pos = conf.position[0];
-		
-		//If relative is false and calculateInlineOffset flag is on then only go for it.
-		if (!conf.relative && conf.calculateInlineOffset) {
-			//Get the actual inline offset of triggered elem
-			var iOffset = $(trigger).inlineOffset();
-			
-			//If element is spans multilines then compare the left positions.  
-			if (left < iOffset.left){
-				left = iOffset.left;
-			}
-		}
+	    
+	    // get origin top/left position 
+	    var top = conf.relative ? trigger.position().top : trigger.offset().top, 
+	       left = conf.relative ? trigger.position().left : trigger.offset().left,
+	       pos = conf.position[0];
+	    
+	    var orgLeftOffset = left; //Keeping original offset
+	    top  -= tip.outerHeight() - conf.offset[0];
+	    left += trigger.outerWidth() + conf.offset[1];
+	    
+	    var isInlineOffsetSet = false;
+	    //If relative is false and calculateInlineOffset flag is on then only go for it.
+	    if (!conf.relative && conf.calculateInlineOffset) {
+	      //Get the actual inline offset of triggered elem
+	      var iOffset = $(trigger).inlineOffset();
 
-		top  -= tip.outerHeight() - conf.offset[0];
-		left += trigger.outerWidth() + conf.offset[1];
-		
-		// iPad position fix
-		if (/iPad/i.test(navigator.userAgent)) {
-			top -= $(window).scrollTop();
-		}
-		
-		// adjust Y		
-		var height = tip.outerHeight() + trigger.outerHeight();
-		if (pos == 'center') 	{ top += height / 2; }
-		if (pos == 'bottom') 	{ top += height; }
-		
-		
-		// adjust X
-		pos = conf.position[1]; 	
-		var width = tip.outerWidth() + trigger.outerWidth();
-		if (pos == 'center') 	{ left -= width / 2; }
-		if (pos == 'left')   	{ left -= width; }	 
-		
-		return {top: top, left: left};
-	}		
+	      //If element is spans multilines then compare the left positions.  
+	      if (orgLeftOffset < iOffset.left){
+	        left = iOffset.left;
+	        isInlineOffsetSet = true;
+	      }
+	    }
+	    
+	    // iPad position fix
+	    if (/iPad/i.test(navigator.userAgent)) {
+	      top -= $(window).scrollTop();
+	    }
+	    
+	    // adjust Y   
+	    var height = tip.outerHeight() + trigger.outerHeight();
+	    if (pos == 'center')  { top += height / 2; }
+	    if (pos == 'bottom')  { top += height; }
+	    
+	    
+	    // adjust X
+	    pos = conf.position[1];   
+	    var width = tip.outerWidth() + trigger.outerWidth();
+	    
+	    //don't apply 'center' in case of setting inline offset value
+	    if (pos == 'center' && !isInlineOffsetSet)  { left -= width / 2;} 
+	    if (pos == 'left')    { left -= width; }   
+	    
+	    return {top: top, left: left};
+	  }		
 
 	
 	

--- a/test/tooltip/multiline-positioning.html
+++ b/test/tooltip/multiline-positioning.html
@@ -1,0 +1,86 @@
+
+<script src="../js/jquery-1.4.1.js"></script>
+<script src="../../src/tooltip/tooltip.js"></script>
+<script src="../../src/tooltip/tooltip.slide.js"></script>
+
+<!--{{{ style -->
+
+<style>
+body {
+	padding:50px 100px;	
+	font-family:sans-serif;	
+}
+
+.tooltip {
+	display:none;
+	width:200px;
+	height:63px;
+	position:absolute;
+	padding:20px;
+	color:#fff;		
+	background-color:#000;
+	-moz-border-radius:4px;
+}
+
+.trigger {
+	border:1px solid #ccc;
+	background-color:#eee;
+	display:block;
+	padding:5px 10px;
+	width:100px;
+	margin:0 20px 10px 0;
+	float:left;
+	text-align:center;
+	-moz-border-radius:4px;
+}
+
+.error{
+  background-color:#A60E0E;
+}
+
+.correct{
+  background:#74A60E;
+}
+
+.test {
+	clear:left;		
+	height:90px;
+}
+#slide p{
+  width:500px;
+  font-size:12px;
+}
+.tooltip-item{
+  border-bottom:2px dotted #C6C3C3;
+}
+</style>
+
+<!--}}}-->
+
+
+
+
+<div id="slide" class="test">
+
+	<h3>Multiline content</h3>
+    <strong>Test case for : without calculating inline offset</strong>
+  <p>
+    jQuery Tools is a collection of the most important user-interface <strong><span class="show-tooltip1 tooltip-item" title="Tooltip is not positioning correctly with the content. <br> :(">components for modern websites.</span></strong> Used by large sites all over the world.
+  </p>
+  <strong>Test case for : with calculating inline offset</strong>
+  <p>
+    jQuery Tools is a collection of the most important user-interface <strong><span class="show-tooltip2 tooltip-item" title="Tooltip is positioning correctly with the content. <br> :)">components for modern websites.</span></strong> Used by large sites all over the world.
+  </p>
+
+<h3>Simple content</h3>
+  <p>
+    <strong><span class="show-tooltip2 tooltip-item" title="Tooltip is positioning correctly with the content. <br> :)">jQuery Tools</span></strong> is a collection of the most important user-interface components for modern websites. Used by <strong><span class="show-tooltip2 tooltip-item" title="Tooltip is positioning correctly with the content. <br> :)">large sites</span></strong> all over the world.
+  </p>
+
+	<script>
+		$("#slide .show-tooltip1").tooltip({ effect: 'slide', opacity: 0.9, calculateInlineOffset : false, onBeforeShow: function(ob, pos) {this.getTip().addClass('error')} });
+    $("#slide .show-tooltip2").tooltip({ effect: 'slide', opacity: 0.9, calculateInlineOffset : true, onBeforeShow: function(ob, pos) {this.getTip().addClass('correct')}  });
+	</script>
+
+</div>
+


### PR DESCRIPTION
Hi,

I have made changes for the following issue:

The scenario is if a tooltip is attached with an inline element which is spread over multiple lines (mostly two) then the position of the tooltip breaks and it appears in the wrong position. In order to fix the issue I have calculated the content position on the basis of an inline element trick, basically the trick is we insert another inline element at the beginning of the target element and calculate the position of the newly inserted element, this makes sure that the tooltip appears at least from the beginning of the content. This is configurable if we set a config option `calculateInlineOffset`, then only it will use the above mentioned technique. 
Attached screen shots to describe the issue.
Wrong positioning of tooltip
![wrong positioning image](http://dl.dropbox.com/u/1615106/tooltip-wrong-positioning.png)

After Correction
![correct image](http://dl.dropbox.com/u/1615106/tooltip-issue-resolved.png)

Thanks
