### PR TITLE
Grow to proper target height in overlay.apple.js

### DIFF
--- a/src/overlay/overlay.apple.js
+++ b/src/overlay/overlay.apple.js
@@ -69,6 +69,9 @@
 		// initial top & left
 		var itop = conf.start.top || Math.round(w.height() / 2), 
 			 ileft = conf.start.left || Math.round(w.width() / 2);
+			
+		// determine target height for overlay
+		var oHeight = overlay.outerHeight({margin:true});
 		
 		if (trigger) {
 			var p = getPosition(trigger);
@@ -101,6 +104,7 @@
 		img.animate({			
 			top: pos.top,
 			left: pos.left,
+			height: oHeight,
 			width: oWidth}, conf.speed, function() {
 			
 			// set close button and content over the image


### PR DESCRIPTION
If the overlay object height is taller than the height of the background image used to render the animation, the resulting overlay ends up being smaller than the actual object height. This patch fixes this.
