### PR TITLE
made tabs work with backbone.js

### DIFF
--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -275,15 +275,21 @@
 			self.click($(this).attr("href"), e);		
 		}); 
 		
+		// Use only the part of location.hash that is in front of the first 
+		// slash. This is for frameworks like Backbone.js where you might have 
+		// a URL like http://example.com/myapp#users/pg/3
+		var slashIndex = location.hash.indexOf("/"),
+			locationHashStr = slashIndex === -1 ? location.hash : location.hash.slice(0, slashIndex);
+
 		// open initial tab
-		if (location.hash && conf.tabs == "a" && root.find("[href=" +location.hash+ "]").length) {
-			self.click(location.hash);
+		if (locationHashStr && conf.tabs == "a" && root.find("[href=" + locationHashStr + "]").length) {
+			self.click(locationHashStr);
 
 		} else {
 			if (conf.initialIndex === 0 || conf.initialIndex > 0) {
 				self.click(conf.initialIndex);
 			}
-		}				
+		}					
 		
 	}
 	


### PR DESCRIPTION
In backbone.js I often find myself with location.hash strings that look like "#users/pg/3".  I ran into a conflict where the #users tab was throwing an error and not opening if I loaded the page with the hash string already in place. So I hacked the code to only use the first segment of the location.hash string.

Please use this if you want.  I realize this was pretty specific to my project, but I thought maybe some other backbone.js people might find this useful.

Perhaps there is a better, more flexible solution to this issue?

thanks for the great library,
Bill
