### PR TITLE
Fix pattern validator failing on optional fields if pattern doesn't allow empty value (Fix #605)

### DIFF
--- a/src/validator/validator.js
+++ b/src/validator/validator.js
@@ -251,9 +251,8 @@
 		return !!v; 			
 	});
 	
-	v.fn("[pattern]", function(el) {
-		var p = new RegExp("^" + el.attr("pattern") + "$");  
-		return p.test(el.val()); 			
+	v.fn("[pattern]", function(el, v) {
+		return v === '' || new RegExp("^" + el.attr("pattern") + "$").test(v);
 	});
 
 	


### PR DESCRIPTION
The following field will fail if no value is provided:

```
<input pattern=".+">
```
