### PR TITLE
Fixed not running the whole next/seekTo function when size == 1

### DIFF
--- a/src/scrollable/scrollable.js
+++ b/src/scrollable/scrollable.js
@@ -152,7 +152,7 @@
 				if (conf.circular && i === 0 && index == -1 && time !== 0) { return self; }
 				
 				// check that index is sane				
-				if (!conf.circular && i < 0 || i > self.getSize() || i < -1) { return self; }
+				if (!conf.circular && i < 0 || (!conf.circular && i >= self.getSize()) ||  i > self.getSize() || i < -1) { return self; }
 				
 				var item = i;
 			


### PR DESCRIPTION
Issue found:
Prev becomes enabled even though there is only one image

Steps:
1) Having scrollable images with only one image and next/prev links.
2) When loading the page the prev/next are disabled properly
3) Clicking the disabled next

Expected Behavior:
Nothing to happen

Actual Behavior:
the seekTo runs and prev is no longer disabled.

Reason:
if (!conf.circular && i < 0 || i > self.getSize() || i < -1) { return self; }         check is not enough
prev.toggleClass(conf.disabledClass, i <= 0); makes the link visible (i==1)
