### PR TITLE
History in 1.2.6 is broken!

### DIFF
--- a/src/toolbox/toolbox.history.js
+++ b/src/toolbox/toolbox.history.js
@@ -27,7 +27,7 @@
 				// create iframe that is constantly checked for hash changes
 				if (!iframe) {
 					iframe = $("<iframe/>").attr("src", "javascript:false;").hide().get(0);
-					$("body").prepend(iframe);
+					$("body").append(iframe);
 									
 					setInterval(function() {
 						var idoc = iframe.contentWindow.document, 


### PR DESCRIPTION
The change from append() to prepend() broke both the ability to reference a tab from a URL, as well as using the browser's back button properly - this fix will revert that change.
