### PR TITLE
Remove iPad fix - Actually breaks the iPad.

### DIFF
--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -449,11 +449,6 @@
 				// show calendar
 				var pos = input.offset();
 
-				// iPad position fix
-				if (/iPad/i.test(navigator.userAgent)) {
-					pos.top -= $(window).scrollTop();
-				}
-				
 				root.css({ 
 					top: pos.top + input.outerHeight({margins: true}) + conf.offset[0], 
 					left: pos.left + conf.offset[1] 


### PR DESCRIPTION
I've been working on a site that uses jQuery tools and the datepicker kept showing up at the top of the page on my test iPad and the way I got it to work was to take out your iPad fix.
