### PR TITLE
The placeholder HTML is assigned twice

### DIFF
--- a/src/toolbox/toolbox.flashembed.js
+++ b/src/toolbox/toolbox.flashembed.js
@@ -226,29 +226,33 @@
 			});
 
 		} else {
-
-			// fail #2.1 custom content inside container
-			if (!root.innerHTML.replace(/\s/g, '')) {
-				root.innerHTML =
-					"<h2>Flash version " + opts.version + " or greater is required</h2>" +
-					"<h3>" +
-						(VERSION[0] > 0 ? "Your version is " + VERSION : "You have no flash plugin installed") +
-					"</h3>" +
-
-					(root.tagName == 'A' ? "<p>Click here to download latest version</p>" :
-						"<p>Download latest version from <a href='" + URL + "'>here</a></p>");
-
-				if (root.tagName == 'A') {
-					root.onclick = function() {
-						location.href = URL;
-					};
-				}
-			}
-
+			var ret;
+			
 			// onFail
 			if (opts.onFail) {
-				var ret = opts.onFail.call(this);
-				if (typeof ret == 'string') { root.innerHTML = ret; }
+				ret = opts.onFail.call(this);
+			}
+			
+			if (typeof ret == 'string') {
+				root.innerHTML = ret;
+			} else {
+				// fail #2.1 custom content inside container
+				if (!root.innerHTML.replace(/\s/g, '')) {
+					root.innerHTML =
+						"<h2>Flash version " + opts.version + " or greater is required</h2>" +
+						"<h3>" +
+							(VERSION[0] > 0 ? "Your version is " + VERSION : "You have no flash plugin installed") +
+						"</h3>" +
+						
+						(root.tagName == 'A' ? "<p>Click here to download latest version</p>" :
+							"<p>Download latest version from <a href='" + URL + "'>here</a></p>");
+					
+					if (root.tagName == 'A') {
+						root.onclick = function() {
+							location.href = URL;
+						};
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
Whether onFail is defined or not, the default placeholder for the Flash content is assigned. Then, onFail is executed to get new content and re-assign it.

This double DOM change that may cause a reflow was noticed to be slow on some mobile devices, so the default placeholder appears for a moment, and then, after onFail that returns an empty string, disappears as intended.

In the commit I've reordered the placeholder HTML assignment to prevent double DOM change via innerHTML.
