### PR TITLE
Allow selected date and today be the same without losing "today" indication when new date is selected

### DIFF
--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -589,14 +589,15 @@
 						num = j - begin + 1;
 						date = new Date(year, month, num);  
 						
+						// today
+						if (isSameDay(now, date)) {
+							a.attr("id", css.today).addClass(css.today);
+						}	 
+						
 						// current date
 						if (isSameDay(value, date)) {
 							a.attr("id", css.current).addClass(css.focus);
-							
-						// today
-						} else if (isSameDay(now, date)) {
-							a.attr("id", css.today);
-						}	 
+						} 
 					}
 					
 					// disabled


### PR DESCRIPTION
Originally, if date under focus is today, then this date would only get focus indication. If then we would select a new date, there would be no indication of "today". This fix allows the same date to be "today" and under focus; thus, when we change the date under focus, today indication will not be lost.
