### PR TITLE
Adding updateTrigger() to get proper trigger positioning when using .delegate()

### DIFF
--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -231,7 +231,13 @@
 			// manipulate start, finish and speeds
 			getConf: function() {
 				return conf;	
-			}			
+			},
+			
+			// in case using .delegate() as your initial trigger
+			// this updates the opening and closing triggers
+			updateTrigger: function($trigger){
+				if( $trigger && $trigger.length>0 ){ trigger = $trigger; }
+			}
 			
 		});
 		


### PR DESCRIPTION
If using .delegate() to initialize your overlay() event, $el.overlay().updateTrigger( $trigger ) will let you update your trigger, mainly to get new starting and ending positions for the Apple effect.
