### PR TITLE
corrected two important bugs (issue #748) in tabs+history 

### DIFF
--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -160,7 +160,10 @@
 			click: function(i, e) {
 			  
 				var tab = tabs.eq(i),
-				    firstRender = !root.data('tabs');
+				    firstRender = !root.data('tabs'),
+                    // we need this to trigger click in the case we're using the effect ajax
+                    // any effect which loads the tabs asynchronously must contain the word "ajax"
+                    isAjax = conf.effect.toLowerCase().indexOf('ajax') >= 0;
 				
 				if (typeof i == 'string' && i.replace("#", "")) {
 					tab = tabs.filter("[href*=\"" + i.replace("#", "") + "\"]");
@@ -188,8 +191,8 @@
 				trigger.trigger(e, [i]);				
 				if (e.isDefaultPrevented()) { return; }
 				
-        // if firstRender, only run effect if initialEffect is set, otherwise default
-				var effect = firstRender ? conf.initialEffect && conf.effect || 'default' : conf.effect;
+        // if firstRender and not using ajax, only run effect if initialEffect is set, otherwise default
+				var effect = firstRender && !isAjax ? conf.initialEffect && conf.effect || 'default' : conf.effect;
 
 				// call the effect
 				effects[effect].call(self, i, function() {
@@ -263,7 +266,9 @@
 	
 		
 		if (conf.history && $.fn.history) {
-			$.tools.history.init(tabs);
+			// if conf.initialIndex is greater than 0 and not null we pass the initial Tab to history.init(), otherwise we pass false (which means do not load anything)
+            var initialTrigger = (conf.initialIndex >= 0 && conf.initialIndex != null) ? self.getTabs().eq(conf.initialIndex) : false ;
+			$.tools.history.init(tabs, initialTrigger);
 			conf.event = 'history';
 		}	
 		
@@ -320,5 +325,4 @@
 	};		
 		
 }) (jQuery); 
-
 

--- a/src/toolbox/toolbox.history.js
+++ b/src/toolbox/toolbox.history.js
@@ -11,15 +11,22 @@
  */
 (function($) {
 		
-	var hash, iframe, links, inited;		
+	var hash, iframe, links, inited, stopFirst;		
 	
 	$.tools = $.tools || {version: '@VERSION'};
 	
 	$.tools.history = {
 	
-		init: function(els) {
+		init: function(els, initialTrigger) {
 			
 			if (inited) { return; }
+            // if there's any initialTrigger value
+            if(initialTrigger){
+                // change the hash to the one of initialTrigger
+                if(!location.hash){ location.hash = initialTrigger.attr("href"); }
+            }
+            // if initialTrigger is false it means we have to avoid triggering the hashchange on the first page load
+            stopFirst = initialTrigger === false;
 			
 			// IE
 			if ($.browser.msie && $.browser.version < '8') {
@@ -87,6 +94,8 @@
 			  return href == h || href == h.replace("#", ""); 
 			}).trigger("history", [h]);	
 		} else {
+            // if stopFirst is false it means we should not trigger the first hash change
+            if(stopFirst){ return false; }
 			links.eq(0).trigger("history", [h]);	
 		}
 


### PR DESCRIPTION
- when using the ajax effect on the tabs the "initialIndex" setting didn't work
- when using the ajax effect on the tabs with the history plugin, the first tab was loaded anyway, regardless of the value of initialIndex

With this patch any custom effect for the tab plugin that performs asynchronous loading must contain the word "ajax" (the check is case insensitive).

I've tested pretty much all the cases.
