### PR TITLE
Adding callback function on overlay close

### DIFF
--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -208,6 +208,10 @@
 				if (maskConf) {
 					$.mask.close();		
 				}
+				
+				if( typeof conf.closeCallback === 'function' ){
+					conf.closeCallback();
+				}
 				 
 				return self;
 			}, 


### PR DESCRIPTION
 IE9 and below keeps letting flash movies play after overlay is closed. Syntax:

$.overlay({
  speed: 400,
  closeCallback: function(){ }
}
