### PR TITLE
Fix for issue #710: flashembed.getVersion is broken since flash player v10.1

### DIFF
--- a/src/toolbox/toolbox.flashembed.js
+++ b/src/toolbox/toolbox.flashembed.js
@@ -11,11 +11,12 @@
  */
 (function() {
 
-	var IE = document.all,
-		 URL = 'http://www.adobe.com/go/getflashplayer',
-		 JQUERY = typeof jQuery == 'function',
-		 RE = /(\d+)[^\d]+(\d+)[^\d]*(\d*)/,
-		 GLOBAL_OPTS = {
+	var
+		IE = document.all,
+		URL = 'http://www.adobe.com/go/getflashplayer',
+		JQUERY = typeof jQuery == 'function',
+		RE = /(\d+)[^\d]+(\d+)[^\d]*(\d*)/,
+		GLOBAL_OPTS = {
 			// very common opts
 			width: '100%',
 			height: '100%',
@@ -32,7 +33,7 @@
 			expressInstall: null,
 			w3c: false,
 			cachebusting: false
-	};
+		};
 
 	// version 9 bugfix: (http://blog.deconcept.com/2006/07/28/swfobject-143-released/)
 	if (window.attachEvent) {
@@ -99,10 +100,10 @@
 					ver = fo && fo.GetVariable("$version");
 
 				} catch(err) {
-                try  {
-                    fo = new ActiveXObject("ShockwaveFlash.ShockwaveFlash.6");
-                    ver = fo && fo.GetVariable("$version");
-                } catch(err2) { }
+					try  {
+						fo = new ActiveXObject("ShockwaveFlash.ShockwaveFlash.6");
+						ver = fo && fo.GetVariable("$version");
+					} catch(err2) { }
 				}
 			}
 

--- a/src/toolbox/toolbox.flashembed.js
+++ b/src/toolbox/toolbox.flashembed.js
@@ -108,7 +108,7 @@
 			}
 
 			ver = RE.exec(ver);
-			return ver ? [ver[1], ver[3]] : [0, 0];
+			return ver ? [parseInt(ver[1], 10), parseInt(ver[2], 10), parseInt(ver[3], 10)] : [0, 0, 0];
 		},
 
 		asString: function(obj) {
@@ -205,7 +205,19 @@
 		},
 
 		isSupported: function(ver) {
-			return VERSION[0] > ver[0] || VERSION[0] == ver[0] && VERSION[1] >= ver[1];
+			var i;
+			if (ver && ver.length > 0) {
+				for (i = 0; i < ver.length && i < VERSION.length; ++i) {
+					if (VERSION[i] > ver[i]) {
+						return true;
+					}
+					else if (VERSION[i] < ver[i]) {
+						return false;
+					}
+				}
+				return true;
+			}
+			return VERSION[0] > 0;
 		}
 
 	});
@@ -219,7 +231,7 @@
 			root.innerHTML = f.getHTML(opts, conf);
 
 		// express install
-		} else if (opts.expressInstall && f.isSupported([6, 65])) {
+		} else if (opts.expressInstall && f.isSupported([6, 0, 65])) {
 			root.innerHTML = f.getHTML(extend(opts, {src: opts.expressInstall}), {
 				MMredirectURL: location.href,
 				MMplayerType: 'PlugIn',


### PR DESCRIPTION
https://github.com/jquerytools/jquerytools/issues/710

flashembed.getVersion() now returns three-element array of [major, minor, release] versions.
flashembed.isSupported() now supports fuzzy version comparison:

```
// Flash installed:
flashembed.getVersion() // => [11, 3, 300]
flashembed.isSupported() // => true
flashembed.isSupported([]) // => true
flashembed.isSupported([10]) // => true
flashembed.isSupported([10, 2]) // => true
flashembed.isSupported([11, 2]) // => true
flashembed.isSupported([11, 4]) // => false
flashembed.isSupported([11, 3, 200]) // => false
flashembed.isSupported([11, 3, 300]) // => true
flashembed.isSupported([12]) // => false

// Flash not installed:
flashembed.getVersion() // => [0, 0, 0]
flashembed.isSupported() // => false
```

External usages of flashembed.getVersion() and flashembed.isSupported() and derivatives (e.g. flowplayer options) must be updated to include the minor version component.
