### PR TITLE
Fix bubbling

### DIFF
--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -752,6 +752,7 @@
 			// clear value on backspace or delete
 			} else if (key == 8 || key == 46) {
 				input.val("");
+				fire.change();
 				} 
 				
 				// allow tab

--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -314,8 +314,7 @@
 			input.val(format(conf.formatter, date, conf.format, conf.lang));
 			
       // change
-			e.type = "change";
-			fire.trigger(e);
+			fire.change();
               
 			// store value into input
 			input.data("date", date);


### PR DESCRIPTION
I'm relying on `$(document).on('change', 'input.foo')` for form validation and it is not triggered by dateInput.js because of two bugs:

1) I don't know why, but the event triggering the date change is reused. The `target` is still set to the day I clicked on, so the event doesn't bubble up properly. My patch disregards the event passed, but if you want you could instead `delete e.target` before firing the event.

I'm no expert in JS, but I find the idea of reusing events (for different types and after they have been fired!) really ugly. Here it's reused after `beforeChange`. What if bubbling is turned off? What if, I don't know, anything was modified?

2) Clearing the date doesn't fire anything.
