### PR TITLE
Send event and date when the date changes.

### DIFF
--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -315,7 +315,7 @@
 			
       // change
 			e.type = "change";
-			fire.trigger(e);
+			fire.trigger(e, [date]);
               
 			// store value into input
 			input.data("date", date);


### PR DESCRIPTION
The changes made to dateinput.js in 9cb13eb15d098a8e7831424d8a8f216cfee3f5f3 removed the date from the parameters sent to the 'change' event. This restores the line.
