### PR TITLE
Fix invalid signature of outerHeight and outerWidth functions

### DIFF
--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -476,8 +476,8 @@
 				}
 				
 				root.css({ 
-					top: pos.top + input.outerHeight({margins: true}) + conf.offset[0], 
-					left: pos.left + conf.offset[1] 
+					top: pos.top + input.outerHeight(true) + conf.offset[0],
+					left: pos.left + conf.offset[1]
 				});
 				
 				if (conf.speed) {

--- a/src/overlay/overlay.apple.js
+++ b/src/overlay/overlay.apple.js
@@ -43,7 +43,7 @@
 			 conf = this.getConf(),
 			 trigger = this.getTrigger(),
 			 self = this,
-			 oWidth = overlay.outerWidth({margin:true}),
+			 oWidth = overlay.outerWidth(true),
 			 img = overlay.data("img"),
 			 position = conf.fixed ? 'fixed' : 'absolute';  
 		

--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -137,8 +137,8 @@
 				// position & dimensions 
 				var top = conf.top,					
 					 left = conf.left,
-					 oWidth = overlay.outerWidth({margin:true}),
-					 oHeight = overlay.outerHeight({margin:true}); 
+					 oWidth = overlay.outerWidth(true),
+					 oHeight = overlay.outerHeight(true); 
 				
 				if (typeof top == 'string')  {
 					top = top == 'center' ? Math.max((w.height() - oHeight) / 2, 0) : 


### PR DESCRIPTION
_This is a re-pull of #849 to target the correct branch_

Reading about [outerheight in jQuery doc](http://api.jquery.com/outerHeight/), it seems like the signature used before (eg `outerHeight({margins:true})`) have never been supported. As an object is a truthy value, I guess it just passed as a true boolean.

Although, as now [`outerHeight` and `outerWidth` can be used as setter (v 1.8)](http://blog.jquery.com/2012/08/16/jquery-1-8-box-sizing-width-csswidth-and-outerwidth/), jQuery now add type validation in these functions ( [1.8](http://james.padolsey.com/jquery/#v=git&fn=jQuery.fn.outerHeight) vs [1.7.2](http://james.padolsey.com/jquery/#v=1.7.2&fn=jQuery.fn.outerHeight) )

So, this fix should defenitly be added to the next version.

Related bugs: #839, #850
