### PR TITLE
fix xss bug on tooltip initialize

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -132,7 +132,8 @@
 			 tip,
 			 timer = 0,
 			 pretimer = 0, 
-			 title = trigger.attr("title"),
+			 // title = trigger.attr("title"), - XSS BUG
+			 title = $('<div/>').text(trigger.attr('title')).html(),
 			 tipAttr = trigger.attr("data-tooltip"),
 			 effect = effects[conf.effect],
 			 shown,


### PR DESCRIPTION
Tooltip doesn't sanitize html when initialized, even though the html passed is already sanitized.
I found a patch from here, but probably a pull request was never done.
https://github.com/OtaK/foundation/commit/eb6877929bc4169ad637818a4a50e6f6b25847bc
