### PR TITLE
Overlay is not centered correctly in JQuery 1.8

### DIFF
--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -137,8 +137,8 @@
 				// position & dimensions 
 				var top = conf.top,					
 					 left = conf.left,
-					 oWidth = overlay.outerWidth({margin:true}),
-					 oHeight = overlay.outerHeight({margin:true}); 
+					 oWidth = overlay.outerWidth(true),
+					 oHeight = overlay.outerHeight(true); 
 				
 				if (typeof top == 'string')  {
 					top = top == 'center' ? Math.max((w.height() - oHeight) / 2, 0) : 


### PR DESCRIPTION
The problem is that for the overlay position calculations, the outerWidth and outerHeight functions are used with the old parameter syntax. I've changed it to the new syntax.

I have not updated any tests, since I was unsure how they worked.
