### PR TITLE
tabs.slideshow: Fixed issues with first and last slide when rotate: false

### DIFF
--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -159,9 +159,10 @@
 		$.extend(this, {				
 			click: function(i, e) {
 			  
-				var tab = tabs.eq(i),
+				var tab = i < 0 ? [] : tabs.eq(i),
 				    firstRender = !root.data('tabs');
 				
+
 				if (typeof i == 'string' && i.replace("#", "")) {
 					tab = tabs.filter("[href*=\"" + i.replace("#", "") + "\"]");
 					i = Math.max(tabs.index(tab), 0);

--- a/src/tabs/tabs.slideshow.js
+++ b/src/tabs/tabs.slideshow.js
@@ -161,6 +161,9 @@
 			
 			if (!tabs.getIndex()) {
 				prevButton.addClass(disabled);
+			} 
+			if (tabs.getIndex() == tabs.getTabs().length -1) {
+				nextButton.addClass(disabled);
 			}
 			
 			tabs.onBeforeClick(function(e, i)  { 


### PR DESCRIPTION
I fixed two issues i had with the tabs.slideshow plugin when clicking back on first slide, and when there is only one slide
