### PR TITLE
Update src/overlay/overlay.js

### DIFF
--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -137,8 +137,8 @@
 				// position & dimensions 
 				var top = conf.top,					
 					 left = conf.left,
-					 oWidth = overlay.outerWidth({margin:true}),
-					 oHeight = overlay.outerHeight({margin:true}); 
+					 oWidth = overlay.outerWidth(true),
+					 oHeight = overlay.outerHeight(true); 
 				
 				if (typeof top == 'string')  {
 					top = top == 'center' ? Math.max((w.height() - oHeight) / 2, 0) : 


### PR DESCRIPTION
outerWidth() in jQuery 1.8.2 takes only [true|false] as argument

also works for jQuery 1.7.0
