### PR TITLE
outerHeight()/outerWidth() fix for jQuery 1.8+

### DIFF
--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -100,8 +100,8 @@
 			 left = conf.relative ? trigger.position().left : trigger.offset().left,
 			 pos = conf.position[0];
 
-		top  -= tip.outerHeight() - conf.offset[0];
-		left += trigger.outerWidth() + conf.offset[1];
+		top  -= tip.outerHeight(false) - conf.offset[0];
+		left += trigger.outerWidth(false) + conf.offset[1];
 		
 		// iPad position fix
 		if (/iPad/i.test(navigator.userAgent)) {
@@ -109,14 +109,14 @@
 		}
 		
 		// adjust Y		
-		var height = tip.outerHeight() + trigger.outerHeight();
+		var height = tip.outerHeight(false) + trigger.outerHeight(false);
 		if (pos == 'center') 	{ top += height / 2; }
 		if (pos == 'bottom') 	{ top += height; }
 		
 		
 		// adjust X
 		pos = conf.position[1]; 	
-		var width = tip.outerWidth() + trigger.outerWidth();
+		var width = tip.outerWidth(false) + trigger.outerWidth(false);
 		if (pos == 'center') 	{ left -= width / 2; }
 		if (pos == 'left')   	{ left -= width; }	 
 		


### PR DESCRIPTION
When using jQuery 1.8+ with some older components (e.g. jQueryUI), outerHeight() and outerWidth() get "duck punched" and they return an object instead of the expected numeric value.  Passing false (which is the default value) fixes the problem.
