### PR TITLE
overlay - allow position from right

### DIFF
--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -31,6 +31,7 @@
 			fixed: !$.browser.msie || $.browser.version > 6, 
 			
 			left: 'center',		
+			right: false,
 			load: false, // 1.2
 			mask: null,  
 			oneInstance: true,
@@ -137,6 +138,7 @@
 				// position & dimensions 
 				var top = conf.top,					
 					 left = conf.left,
+					 right = conf.right,
 					 oWidth = overlay.outerWidth({margin:true}),
 					 oHeight = overlay.outerHeight({margin:true}); 
 				
@@ -147,9 +149,18 @@
 				
 				if (left == 'center') { left = Math.max((w.width() - oWidth) / 2, 0); }
 
-				
+				var position = {top: top};
+
+				// position from right if defined
+				if (right !== false) {
+					position.right = right;
+				}
+				else {
+					position.left = left;
+				}
+
 		 		// load effect  		 		
-				eff[0].call(self, {top: top, left: left}, function() {					
+				eff[0].call(self, position, function() {
 					if (opened) {
 						e.type = "onLoad";
 						fire.trigger(e);


### PR DESCRIPTION
Added "right" as a setting for the position of the Overlay.

I needed the overlay to stick to the right side of the window for all screensizes and on horizontal scrolling.

commit-message:

``````
works like the "left"-setting but:
* has no 'center' (unneeded - use left:'center' instead
* defaults to false (unused), is only used if a pixel or % value is set```
``````
