### PR TITLE
Update src/tabs/tabs.slideshow.js

### DIFF
--- a/src/tabs/tabs.slideshow.js
+++ b/src/tabs/tabs.slideshow.js
@@ -54,6 +54,7 @@
     *   Similar fix for autoscroll animation queue problem
     */
     function next(){
+      clearTimeout(timer);
       timer = setTimeout(function(){
         tabs.next();
       }, conf.interval);


### PR DESCRIPTION
The next function was not clearing the existing 'setTimeout' call. If you clicked rapidly through tabs you would get unexpected results. Adding 'clearTimeout(timer);' seemed to fix this problem and not interfere with autoscrolling.
