### PR TITLE
Fixing overlay for jQuery 1.8.2

### DIFF
--- a/src/overlay/overlay.apple.js
+++ b/src/overlay/overlay.apple.js
@@ -43,7 +43,7 @@
 			 conf = this.getConf(),
 			 trigger = this.getTrigger(),
 			 self = this,
-			 oWidth = overlay.outerWidth({margin:true}),
+			 oWidth = overlay.outerWidth(true),
 			 img = overlay.data("img"),
 			 position = conf.fixed ? 'fixed' : 'absolute';  
 		

--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -137,8 +137,8 @@
 				// position & dimensions 
 				var top = conf.top,					
 					 left = conf.left,
-					 oWidth = overlay.outerWidth({margin:true}),
-					 oHeight = overlay.outerHeight({margin:true}); 
+					 oWidth = overlay.outerWidth(true),
+					 oHeight = overlay.outerHeight(true);
 				
 				if (typeof top == 'string')  {
 					top = top == 'center' ? Math.max((w.height() - oHeight) / 2, 0) : 


### PR DESCRIPTION
The outerWidth and outerHeight jquery functions have always expected a boolean argument. In the previous versions, jQuery accepted a "truthy" value instead of a strict boolean.  As of 1.8, a boolean true or false is required.
