### PR TITLE
Fixed memory leak in overlay library

### DIFF
--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -186,6 +186,11 @@
 			}, 
 			
 			close: function(e) {
+				var instanceIndex = instances.indexOf(this);
+				
+				if(instanceIndex > -1){
+					instances.splice(instanceIndex, 1);
+				}
 
 				if (!self.isOpened()) { return self; }
 				


### PR DESCRIPTION
Overlays are added to the instances array, and never removed.  This means that DOM elements would leak over time

Added necessary cleanup to the overlays `close` method
