### PR TITLE
Update Tooltip and DateInput to use jQuery 1.9.1

### DIFF
--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -283,7 +283,7 @@
 			currDay	 = date.getDate();				
 			
 			// focus the input after selection (doesn't work in IE)
-			if (e.type == "click" && !$.browser.msie) {
+			if (e.type == "click" && !/msie/.test(navigator.userAgent.toLowerCase())) {
 				input.focus();
 			}
 			

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -69,7 +69,7 @@
 		fade: [
 			function(done) {
 				var conf = this.getConf();
-				if (!$.browser.msie || conf.fadeIE) {
+				if (!/msie/.test(navigator.userAgent.toLowerCase()) || conf.fadeIE) {
 					this.getTip().fadeTo(conf.fadeInSpeed, conf.opacity, done);
 				}
 				else {
@@ -79,7 +79,7 @@
 			},
 			function(done) {
 				var conf = this.getConf();
-				if (!$.browser.msie || conf.fadeIE) {
+				if (!/msie/.test(navigator.userAgent.toLowerCase()) || conf.fadeIE) {
 					this.getTip().fadeOut(conf.fadeOutSpeed, done);
 				}
 				else {

--- a/src/tooltip/tooltip.slide.js
+++ b/src/tooltip/tooltip.slide.js
@@ -21,7 +21,7 @@
 		slideOffset: 10,
 		slideInSpeed: 200,
 		slideOutSpeed: 200, 
-		slideFade: !$.browser.msie
+		slideFade: !/msie/.test(navigator.userAgent.toLowerCase())
 	});			
 	
 	// directions for slide effect


### PR DESCRIPTION
This change is to make Tooltip and DateInput compatible with jQuery 1.9.1
