### PR TITLE
Update Overlay's Apple functionality to work with jQuery 1.9.1

### DIFF
--- a/src/overlay/overlay.apple.js
+++ b/src/overlay/overlay.apple.js
@@ -43,7 +43,7 @@
 			 conf = this.getConf(),
 			 trigger = this.getTrigger(),
 			 self = this,
-			 oWidth = overlay.outerWidth({margin:true}),
+			 oWidth = overlay.outerWidth({true}),
 			 img = overlay.data("img"),
 			 position = conf.fixed ? 'fixed' : 'absolute';  
 		


### PR DESCRIPTION
This change is to update Overlay's apple functionality to work correctly with jQuery 1.9.1
