### PR TITLE
Update Overlay to use jQuery 1.9.1

### DIFF
--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -28,7 +28,7 @@
 			effect: 'default',
 			
 			// since 1.2. fixed positioning not supported by IE6
-			fixed: !$.browser.msie || $.browser.version > 6, 
+			fixed: !/msie/.test(navigator.userAgent.toLowerCase()) || navigator.appVersion > 6, 
 			
 			left: 'center',		
 			load: false, // 1.2


### PR DESCRIPTION
This change updates Overlay to be compatible with jQuery 1.9.1
