### PR TITLE
Fixed the dateinput month/year dropdown bug in Firefox 20 (issue #982)

### DIFF
--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -401,8 +401,8 @@
 			// click outside dateinput
 			$(document).on("click.d", function(e) {					
 				var el = e.target;
-				
-				if (!$(el).parents("#" + css.root).length && el != input[0] && (!trigger || el != trigger[0])) {
+				// && (el != document) fixed the FF20 bug (issue #982)
+				if (!$(el).parents("#" + css.root).length && el != input[0] && (!trigger || el != trigger[0]) && (el != document)) {	
 					self.hide(e);
 				}
 				


### PR DESCRIPTION
In case of FF20 the el variable (e.target inside the $(document).on("click.d", function(e) {...} ) is [object HTMLDocument] and so the parents.length is 0.
The reason seems to be the monthSelector.emty(), monthSelector.append() stuff inside the setValue() function. Im able to fix it by excluding this case.

I am sure that this is not the smartest way to fix it, but it seems to work.
