### PR TITLE
fixed syntax error and browser detection

### DIFF
--- a/src/overlay/overlay.apple.js
+++ b/src/overlay/overlay.apple.js
@@ -43,7 +43,7 @@
 			 conf = this.getConf(),
 			 trigger = this.getTrigger(),
 			 self = this,
-			 oWidth = overlay.outerWidth({true}),
+			 oWidth = overlay.outerWidth(true),
 			 img = overlay.data("img"),
 			 position = conf.fixed ? 'fixed' : 'absolute';  
 		

--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -28,7 +28,7 @@
 			effect: 'default',
 			
 			// since 1.2. fixed positioning not supported by IE6
-			fixed: !/msie/.test(navigator.userAgent.toLowerCase()) || navigator.appVersion > 6, 
+			fixed: !document.all || !!window.XMLHttpRequest, // XMLHttpRequest exists from IE7
 			
 			left: 'center',		
 			load: false, // 1.2


### PR DESCRIPTION
!document.all || !!window.XMLHttpRequest - commonly used hack
i test it with Chrome 27.0.1453.94, Firefox 20.0.1, IE6,7,8,9 - is work right
