### PR TITLE
Fixed blank problem with blank position()

### DIFF
--- a/src/scrollable/scrollable.js
+++ b/src/scrollable/scrollable.js
@@ -170,7 +170,7 @@
 					if (e.isDefaultPrevented() || !item.length) { return self; }			
 				}  
 	
-				var props = vertical ? {top: -item.position().top} : {left: -item.position().left};  
+				var props = vertical ? {top: -item.position() ? -item.position().top : 0} : {left: -item.position().left};  
 				
 				index = i;
 				current = self;  

--- a/src/scrollable/scrollable.js
+++ b/src/scrollable/scrollable.js
@@ -170,7 +170,7 @@
 					if (e.isDefaultPrevented() || !item.length) { return self; }			
 				}  
 	
-				var props = vertical ? {top: -item.position() ? -item.position().top : 0} : {left: -item.position().left};  
+				var props = vertical ? {top: -item.position() ? -item.position().top : 0} : {left: -item.position() ? -item.position().left : 0};  
 				
 				index = i;
 				current = self;  

--- a/src/scrollable/scrollable.js
+++ b/src/scrollable/scrollable.js
@@ -170,7 +170,10 @@
 					if (e.isDefaultPrevented() || !item.length) { return self; }			
 				}  
 	
-				var props = vertical ? {top: -item.position() ? -item.position().top : 0} : {left: -item.position() ? -item.position().left : 0};  
+				var props = 0;
+				if (item.position()) {
+					props = vertical ? {top: -item.position().top} : {left: -item.position().left};  
+				}
 				
 				index = i;
 				current = self;  


### PR DESCRIPTION
I noticed that when scrollable does not have a full complement of items (blank spaces) an error will be thrown when circular is turned on. I have adjusted for this error by returning an top value of 0 when there is no top value.
