### PR TITLE
fixed bug in url validator with escaped characters

### DIFF
--- a/src/validator/validator.js
+++ b/src/validator/validator.js
@@ -21,7 +21,7 @@
 		
 		// http://net.tutsplus.com/tutorials/other/8-regular-expressions-you-should-know/
 		emailRe = /^([a-z0-9_\.\-\+]+)@([\da-z\.\-]+)\.([a-z\.]{2,6})$/i,
-		urlRe = /^(https?:\/\/)?[\da-z\.\-]+\.[a-z\.]{2,6}[#&+_\?\/\w \.\-=]*$/i,
+		urlRe = /^(https?:\/\/)?[\da-z\.\-]+\.[a-z\.]{2,6}[#&+_\?\/\w \.\-=%]*$/i,
 		v;
 		 
 	v = $.tools.validator = {


### PR DESCRIPTION
e.g. https://de.wikipedia.org/wiki/%C3%9C would not validate
