### PR TITLE
Wip overlay position from right

### DIFF
--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -30,7 +30,8 @@
 			// since 1.2. fixed positioning not supported by IE6
 			fixed: !/msie/.test(navigator.userAgent.toLowerCase()) || navigator.appVersion > 6, 
 			
-			left: 'center',		
+			left: 'center',
+			right: false,
 			load: false, // 1.2
 			mask: null,  
 			oneInstance: true,
@@ -135,10 +136,11 @@
 				if (maskConf) { $(overlay).expose(maskConf); }				
 				
 				// position & dimensions 
-				var top = conf.top,					
-					 left = conf.left,
-					 oWidth = overlay.outerWidth(true),
-					 oHeight = overlay.outerHeight(true); 
+				var top = conf.top,
+					left = conf.left,
+					right = conf.right,
+					oWidth = overlay.outerWidth(true),
+					oHeight = overlay.outerHeight(true);
 				
 				if (typeof top == 'string')  {
 					top = top == 'center' ? Math.max((w.height() - oHeight) / 2, 0) : 
@@ -147,9 +149,18 @@
 				
 				if (left == 'center') { left = Math.max((w.width() - oWidth) / 2, 0); }
 
-				
+				var position = {top: top};
+
+				// position from right if defined
+				if (right !== false) {
+					position.right = right;
+				}
+				else {
+					position.left = left;
+				}
+
 		 		// load effect  		 		
-				eff[0].call(self, {top: top, left: left}, function() {					
+				eff[0].call(self, position, function() {
 					if (opened) {
 						e.type = "onLoad";
 						fire.trigger(e);


### PR DESCRIPTION
Thats a manual merge of my pull request #891 from last year.

Added "right" as a setting for the position of the Overlay.

I needed the overlay to stick to the right side of the window for all screensizes and on horizontal scrolling.

```
works like the "left"-setting but:
    * has no 'center' (unneeded - use left:'center' instead
    * defaults to false (unused), is only used if a pixel or % value is set
    * if left and right are set, left will be ignored
```
