### PR TITLE
Fixed the disabling of the next button when multiple items are shown at once in a scrollable

### DIFF
--- a/src/scrollable/scrollable.js
+++ b/src/scrollable/scrollable.js
@@ -264,7 +264,7 @@
 				setTimeout(function() {
 					if (!e.isDefaultPrevented()) {
 						prev.toggleClass(conf.disabledClass, i <= 0);
-						next.toggleClass(conf.disabledClass, i >= self.getSize() -1);
+						next.toggleClass(conf.disabledClass, i >= self.getSize() -conf.size);
 					}
 				}, 1);
 			});


### PR DESCRIPTION
When scrolling by more than one item in a scrollable, the next button does not get disabled correctly.
