### PR TITLE
Dev - allow closeOnClick and closeOnEsc to be toggled after the overlay has been instantiated

### DIFF
--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -79,9 +79,10 @@
 			 overlay,
 			 opened,
 			 maskConf = $.tools.expose && (conf.mask || conf.expose),
-			 uid = globalId++;
+			 uid = globalId++,
+			 closeOnClick = conf.closeOnClick,
+			 closeOnEsc = conf.closeOnEsc;
 		
-			 
 		// mask configuration
 		if (maskConf) {			
 			if (typeof maskConf == 'string') { maskConf = {color: maskConf}; }
@@ -97,7 +98,7 @@
 		
 		// trigger's click event
 		if (trigger && trigger.index(overlay) == -1) {
-			trigger.click(function(e) {				
+			trigger.click(function(e) {
 				self.load(e);
 				return e.preventDefault();
 			});
@@ -157,31 +158,30 @@
 				}); 				
 
 				// mask.click closes overlay
-				if (maskConf && conf.closeOnClick) {
-					$.mask.getMask().one("click", self.close); 
+				if (maskConf) {
+					$.mask.getMask().one("click", function() {
+						console.log(closeOnClick);
+						if (closeOnClick) {
+							self.close();
+						}
+					}); 
 				}
 				
 				// when window is clicked outside overlay, we close
-				if (conf.closeOnClick) {
-					$(document).on("click." + uid, function(e) { 
-						if (!$(e.target).parents(overlay).length) { 
-							self.close(e); 
-						}
-					});						
-				}						
+				$(document).on("click." + uid, function(e) {
+					if (closeOnClick && !$(e.target).parents(overlay).length) {
+						self.close(e);
+					}
+				});
 			
 				// keyboard::escape
-				if (conf.closeOnEsc) { 
+				// one callback is enough if multiple instances are loaded simultaneously
+				$(document).on("keydown." + uid, function(e) {
+					if (closeOnEsc && e.keyCode == 27) {
+						self.close(e);
+					}
+				});
 
-					// one callback is enough if multiple instances are loaded simultaneously
-					$(document).on("keydown." + uid, function(e) {
-						if (e.keyCode == 27) { 
-							self.close(e);	 
-						}
-					});			
-				}
-
-				
 				return self; 
 			}, 
 			
@@ -235,7 +235,25 @@
 			// manipulate start, finish and speeds
 			getConf: function() {
 				return conf;	
-			}			
+			},
+
+			setCloseOnClick: function(bool) {
+				closeOnClick = bool;
+				return this;
+			},
+
+			getCloseOnClick: function() {
+				return closeOnClick;
+			},
+
+			setCloseOnEsc: function(bool) {
+				closeOnEsc = bool;
+				return this;
+			},
+
+			getCloseOnEsc: function() {
+				return closeOnEsc;
+			}
 			
 		});
 		
@@ -291,7 +309,7 @@
 		});
 		
 		return conf.api ? el: this;		
-	}; 
-	
+	};
+
 })(jQuery);
 

--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -39,7 +39,25 @@
 			top: '10%'
 		},
 
-		overlays: function() {
+		// takes a dom element or a jquery selector or nothing
+		// will return all overlay instances if nothing or the overlay instance for a given element
+		overlays: function(el) {
+			var instanceElement, overlayInstance;
+
+			if (el) {
+				el = el["context"] || el;
+
+				// this is slow but should be small
+				for (var i=0 ; i < instances.length; i++ ) {
+					overlayInstance = instances[i];
+					instanceElement = overlayInstance.getTrigger()[0];
+
+					if (instanceElement == el) {
+						return overlayInstance; // short circuit b/c there is only 1 overlay for this selector
+					}
+				};
+			}
+
 			return instances;
 		}
 	};

--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -41,7 +41,11 @@
 
 		overlays: function() {
 			return instances;
-		}
+		},
+
+		hasOverlay: function(el) {
+			$(el).data("overlay") ? true : false;
+		},
 	};
 
 	

--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -37,6 +37,10 @@
 			speed: 'normal',
 			target: null, // target element to be overlayed. by default taken from [rel]
 			top: '10%'
+		},
+
+		overlays: function() {
+			return instances;
 		}
 	};
 

--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -41,7 +41,7 @@
 	};
 
 	
-	var instances = [], effects = {};
+	var instances = [], effects = {}, globalId = 0;
 		
 	// the default effect. nice and easy!
 	$.tools.overlay.addEffect('default', 
@@ -79,7 +79,7 @@
 			 overlay,
 			 opened,
 			 maskConf = $.tools.expose && (conf.mask || conf.expose),
-			 uid = Math.random().toString().slice(10);		
+			 uid = globalId++;
 		
 			 
 		// mask configuration
@@ -212,6 +212,10 @@
 				return self;
 			}, 
 			
+			getId: function() {
+				return uid;
+			},
+
 			getOverlay: function() {
 				return overlay;	
 			},

--- a/src/overlay/overlay.js
+++ b/src/overlay/overlay.js
@@ -39,25 +39,7 @@
 			top: '10%'
 		},
 
-		// takes a dom element or a jquery selector or nothing
-		// will return all overlay instances if nothing or the overlay instance for a given element
-		overlays: function(el) {
-			var instanceElement, overlayInstance;
-
-			if (el) {
-				el = el["context"] || el;
-
-				// this is slow but should be small
-				for (var i=0 ; i < instances.length; i++ ) {
-					overlayInstance = instances[i];
-					instanceElement = overlayInstance.getTrigger()[0];
-
-					if (instanceElement == el) {
-						return overlayInstance; // short circuit b/c there is only 1 overlay for this selector
-					}
-				};
-			}
-
+		overlays: function() {
 			return instances;
 		}
 	};

--- a/test/overlay/index.htm
+++ b/test/overlay/index.htm
@@ -29,6 +29,7 @@
 <script>
 $("a[rel]").overlay({
 	closeOnClick: false,
+	closeOnEsc: false,
 	
 	mask: { 
 		color: '#ccc',

--- a/test/overlay/index.htm
+++ b/test/overlay/index.htm
@@ -29,7 +29,6 @@
 <script>
 $("a[rel]").overlay({
 	closeOnClick: false,
-	closeOnEsc: false,
 	
 	mask: { 
 		color: '#ccc',


### PR DESCRIPTION
There are a few different ideas conflating in this patch, but the general idea is to add some more programability to overlays. The following changes have been made...
1. Exposed closeOnClick and closeOnEsc methods that allow you to change this option once an overlay is constructed. For example, you can now create an overlay that can be closed, and then if conditions change, you can disable that ability. This was previously very difficult to do. This also means that the eventhandler is added to all overlays and is toggled by the values of the closeOnClick and closeOnEsc variables.
2. Since overlays are singletons, I've added the overlays function which will return all overlay that have been instantiated. I've also changed the uid function to use an incrementing counter instead of a random number.
3. Added a simple function which will return a boolean indicating whether or not an element has an overlay attached to it. This is just a convenience method.
