### PR TITLE
Fixed calendar top position bug for current versions of jQuery.

### DIFF
--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -471,7 +471,7 @@
 				}
 				
 				root.css({ 
-					top: pos.top + input.outerHeight({margins: true}) + conf.offset[0], 
+					top: pos.top + conf.offset[0] + input.outerHeight(true), 
 					left: pos.left + conf.offset[1] 
 				});
 				


### PR DESCRIPTION
Is this project even still alive? I needed an up-to-date version for some outdated JavaScript files but an up-to-date jQuery library. I added halfbaked's fix from the bug tracker which fixes the "position top" bug that started cropping up in jQuery 1.8.0+. I'm not sure if the fix now breaks the legacy libraries, but who cares? Out with the old, in with the new.
