### PR TITLE
Recognize the tilde character as valid for the url validator

### DIFF
--- a/src/validator/validator.js
+++ b/src/validator/validator.js
@@ -21,7 +21,7 @@
 		
 		// http://net.tutsplus.com/tutorials/other/8-regular-expressions-you-should-know/
 		emailRe = /^([a-z0-9_\.\-\+]+)@([\da-z\.\-]+)\.([a-z\.]{2,6})$/i,
-		urlRe = /^(https?:\/\/)?[\da-z\.\-]+\.[a-z\.]{2,6}[#&+_\?\/\w \.\-=]*$/i,
+		urlRe = /^(https?:\/\/)?[\da-z\.\-]+\.[a-z\.]{2,6}[#&+_\?\/\w \.\-=~]*$/i,
 		v;
 		 
 	v = $.tools.validator = {


### PR DESCRIPTION
The regexp used for validating urls didn't recognize the tilde character as a valid character, so valid urls of the form http://example.org/~user would not be validated successfully.
