### PR TITLE
Allow custom positioning callback for the dateinput

### DIFF
--- a/src/dateinput/dateinput.js
+++ b/src/dateinput/dateinput.js
@@ -41,6 +41,7 @@
 			trigger: 0,
 			toggle: 0,
 			editable: 0,
+			positioner: undefined,
 			
 			css: {
 				
@@ -240,7 +241,11 @@
 			
 			// root
 			root = $('<div><div><a/><div/><a/></div><div><div/><div/></div></div>')
-				.hide().css({position: 'absolute'}).attr("id", css.root);			
+				.hide().attr("id", css.root);
+			
+			if (!conf.positioner){
+				root.css({position: 'absolute'})
+			}
 						
 			// elements
 			root.children()
@@ -467,18 +472,22 @@
 				// set date
 				self.setValue(value);				 
 				
-				// show calendar
-				var pos = input.offset();
+				if (conf.positioner){
+					conf.positioner(input, root, conf);
+				} else {
+					// show calendar
+					var pos = input.offset();
 
-				// iPad position fix
-				if (/iPad/i.test(navigator.userAgent)) {
-					pos.top -= $(window).scrollTop();
+					// iPad position fix
+					if (/iPad/i.test(navigator.userAgent)) {
+						pos.top -= $(window).scrollTop();
+					}
+					
+					root.css({ 
+						top: pos.top + input.outerHeight(true) + conf.offset[0], 
+						left: pos.left + conf.offset[1] 
+					});
 				}
-				
-				root.css({ 
-					top: pos.top + input.outerHeight(true) + conf.offset[0], 
-					left: pos.left + conf.offset[1] 
-				});
 				
 				if (conf.speed) {
 					root.show(conf.speed, function() {


### PR DESCRIPTION
When using a date input within a fixed position element such as a dialog there is a positioning problem due to scrolling. The best way to resolve this seems to be to have the calendar root div inserted adjacent to the input and to position them through CSS.

In order to facilitate this in a generic manner I've added a configuration parameter to allow custom positioning of the calendar when it is shown.

I looked at having it detect if the input had a fixed position ancestor but doing this would require wrapping the original input in extra markup and that seemed a bit too intrusive.

Using this configuration parameter in the fixed dialog scenario looks a bit like this:

```
$(".date").dateinput({
    format: "dd/mm/yyyy",
    positioner: function (input, calroot, conf) {
        input.after(calroot);
    }
});
```
