### PR TITLE
Do not remove disabledClass when there is only 1 page

### DIFF
--- a/src/scrollable/scrollable.js
+++ b/src/scrollable/scrollable.js
@@ -263,7 +263,7 @@
 			self.onBeforeSeek(function(e, i) {
 				setTimeout(function() {
 					if (!e.isDefaultPrevented()) {
-						prev.toggleClass(conf.disabledClass, i <= 0);
+						prev.toggleClass(conf.disabledClass, i <= 0 || self.getSize() === 1);
 						next.toggleClass(conf.disabledClass, i >= self.getSize() -1);
 					}
 				}, 1);


### PR DESCRIPTION
Fix a bug where pressing the "next" button on a scrollable instance that only has 1 page would remove the disabledClass of the "prev" button.
JSfiddle to reproduce:
http://jsfiddle.net/6KKM6/1/
