### PR TITLE
Fix email & URL validation for ntlds

### DIFF
--- a/src/validator/validator.js
+++ b/src/validator/validator.js
@@ -20,8 +20,8 @@
 		dateInput = $.tools.dateinput,
 		
 		// http://net.tutsplus.com/tutorials/other/8-regular-expressions-you-should-know/
-		emailRe = /^([a-z0-9_\.\-\+]+)@([\da-z\.\-]+)\.([a-z\.]{2,6})$/i,
-		urlRe = /^(https?:\/\/)?[\da-z\.\-]+\.[a-z\.]{2,6}[#&+_\?\/\w \.\-=]*$/i,
+		emailRe = /^([a-z0-9_\.\-\+]+)@([\da-z\.\-]+)\.([\da-z\.\-]{2,63})$/i,
+		urlRe = /^(https?:\/\/)?[\da-z\.\-]+\.[\da-z\.\-]{2,63}[#&+_\?\/\w \.\-=]*$/i,
 		v;
 		 
 	v = $.tools.validator = {


### PR DESCRIPTION
Try to fix validation for new TLDs like .international or .xn--1qqw23a
