### PR TITLE
The .size() method is deprecated as of jQuery 1.8 and removed in 3.0,…

### DIFF
--- a/src/scrollable/scrollable.js
+++ b/src/scrollable/scrollable.js
@@ -81,7 +81,7 @@
 			}, 
 
 			getSize: function() {
-				return self.getItems().size();	
+				return self.getItems().length;	
 			},
 
 			getNaviButtons: function() {


### PR DESCRIPTION
The .size() method is deprecated as of jQuery 1.8 and removed in 3.0, use the .length property instead
https://api.jquery.com/size/